### PR TITLE
Be respectful of node.js trademark

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <h1>Javascript I/O</h1>
 
     <h2>
-      <a href="https://github.com/iojs/io.js"><code>io.js</code></a> is a <a href="https://nodejs.org">node</a> &amp; <a href="https://www.npmjs.org/">npm</a> compatible javascript platform.
+      <a href="https://github.com/iojs/io.js"><code>io.js</code></a> is a <a href="https://nodejs.org">node.js</a> &amp; <a href="https://www.npmjs.org/">npm</a> compatible javascript platform.
     </h2>
 
     <p>
@@ -91,5 +91,11 @@
       </br>
       That's your kind of thing, right?
     </a>
+
+    <p>
+      <small>Node.js is a <a href="http://nodejs.org/images/trademark-policy.pdf">trademark</a> of
+        <a href="http://www.joyent.com/">Joyent, Inc.</a></small>
+    </p>
+
   </body>
 </html>


### PR DESCRIPTION
Making reference to node on the landing page should probably include a reference to the Joyent trademark.
