### PR TITLE
Add more information to the homepage to explain what io.js is.

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,12 @@
     <p class="lead">
       <a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>&#8482;.
     </p>
-
+    <p class="small">
+      io.js merges in the latest updates to V8, libuv, and other base libraries while merging the existing work on
+      Node.js 0.11.x and 0.10.x. The goal is to continue Node development under an 
+      <a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">open governance</a> model and
+      to move toward a proper ES6-compatible stable release. io.js will have faster release cycles than Node.js.
+    </p>
     <div class="release">
       <a href="https://iojs.org/dist/v1.0.1/" class="release-logo-link">
         <img class="release-logo" src="images/1.0.0.png" />
@@ -43,6 +48,13 @@
           <!-- Jan 13th 2015 -->
           <a href="https://iojs.org/dist/v1.0.1/">Version 1.0.1 <em>(Beta stability)</em></a>
         </span>
+        <span class="release-changelog">
+          <a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">View the Changelog</a>
+        </span>
+        <p class="small">
+          io.js has moved to <a href="http://semver.org/">Semver</a>. 1.0.x does not necessarily mean io.js is
+          production ready, but that it is a significant enough release to warrant a major version increment.
+        </p>
         <br>
         <span class="release-downloads">
           Download for

--- a/style.css
+++ b/style.css
@@ -131,6 +131,15 @@ ul {
   color: black;
 }
 
+.release-changelog {
+  display: block;
+  font-size: 0.8rem;
+}
+
+.release-changelog a {
+  text-decoration: underline;
+}
+
 .release-version em {
   color: rgba(0, 0, 0, 0.5);
   font-style: normal;
@@ -173,6 +182,10 @@ nav a:hover {
 
 p.lead {
   text-align:center;
+}
+
+p.small {
+  font-size: 12px;
 }
 
 @media (max-width: 560px) {
@@ -224,6 +237,10 @@ p.lead {
   }
   .release-version {
     text-align: center;
+  }
+  .release-changelog {
+    text-align: center;
+    font-size: 0.7rem;
   }
   .release-details {
     padding-left: initial;


### PR DESCRIPTION
On nearly every thread I've seen on social media about io.js (HN, Reddit, etc.), a good portion of the dominant conversation circles around [Okay, what is this?](https://news.ycombinator.com/item?id=8884183) rather than the far more interesting conversation about what io.js brings to the table, how it can be used today, what it means for Node going forward, etc., etc.

While some of this information is available in the FAQ, even the FAQ is sparse and needs expansion (for a later PR).

This PR adds what I believe is the most useful information to have at a glance on the homepage to properly explain what io.js is and what it means to developers. io.js is going to have to educate devs if it wants them to use it, so information needs to be ready and available, rather than hidden behind other pages or in the repo.

![Imgur](http://i.imgur.com/0UNafVF.jpg)