### PR TITLE
add DOCS for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <div class="spacer"></div>
       <a href="faq.html">FAQ</a>
       <a href="es6.html">ES6</a>
-      <a href="https://iojs.org/api/">API</a>
+      <a href="https://iojs.org/api/">API DOCS</a>
     </div>
   </header>
 


### PR DESCRIPTION
I thought io.js didn't have a documentation page as node.js because there was only this 'API' link and I was expecting "docs".

This small commit adds 'DOCS' to the same link.