### PR TITLE
2015-01-19 WG - meeting details section added

### DIFF
--- a/wg-meetings/2015-01-19.md
+++ b/wg-meetings/2015-01-19.md
@@ -1,5 +1,15 @@
-## YouTube
-https://www.youtube.com/watch?v=RgZAw-etur8
+## Meeting Details
+- Monday January 19, 2015 at 19:00 UTC
+- Original GitHub Issue (planning thread): https://github.com/iojs/website/issues/59
+- YouTube recording: https://www.youtube.com/watch?v=RgZAw-etur8
+- In attendance (_in order of self-introduction_):
+  * Mikeal Rogers [@mikeal](https://github.com/mikeal), _meeting chair_
+  * Jeremiah Senkpiel [@Fishrock123](https://github.com/Fishrock123)
+  * Sean Ouimet [@snostorm](https://github.com/snostorm)
+  * Trent Oswald [@therebelrobot](https://github.com/therebelrobot)
+  * Zeke Sikelianos [@zeke](https://github.com/zeke)
+  * Charlie Robbins [@indexzero](https://github.com/indexzero)
+
 ## Meeting Agenda
 ### Matching or Diverging from io.js organizationally
 * Governance #81


### PR DESCRIPTION
I didn't go thru the notes to add usernames beside first names, but at least the guide at the top helps