### PR TITLE
Removes transition-period {index,es6,faq}.html fallback files #22

### DIFF
--- a/es6.html
+++ b/es6.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <!-- NOTE FOR FUTURE DEVS: this is a _very_ temporary file
-         while iojs.org shifts server settings. Please remove me. -->
-    <meta http-equiv="refresh" content="0;./public/es6.html">
-    <script>window.location.href='./public/es6.html';</script>
-  </head>
-</html>

--- a/faq.html
+++ b/faq.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <!-- NOTE FOR FUTURE DEVS: this is a _very_ temporary file
-         while iojs.org shifts server settings. Please remove me. -->
-    <meta http-equiv="refresh" content="0;./public/faq.html">
-    <script>window.location.href='./public/faq.html';</script>
-  </head>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <!-- NOTE FOR FUTURE DEVS: this is a _very_ temporary file
-         while iojs.org shifts server settings. Please remove me. -->
-    <meta http-equiv="refresh" content="0;./public/index.html">
-    <script>window.location.href='./public/index.html';</script>
-  </head>
-</html>


### PR DESCRIPTION
As per #22 now that #26 is closed, we don't need these files.

FYI I did a minor "manual push to master" today -https://github.com/iojs/website/commit/fb9ccd756dad3a189a9ff160629bd58cf091fa2a - as we needed to test the deploy script post merge

I left this cleanup as a PR so everyone is more aware that the ./public directory change is now live. Or incase anybody wants these fallbacks to stay for some reason.