### PR TITLE
io.js v1.0.4 release

### DIFF
--- a/public/es6.html
+++ b/public/es6.html
@@ -31,7 +31,7 @@
     <div class="description">
 
       <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-      <p>Version 1.0.3 of io.js ships with V8 4.1.0.7, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+      <p>Version 1.0.4 of io.js ships with V8 4.1.0.12, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
     </div>
 
     <div class="faq-item">

--- a/public/index.html
+++ b/public/index.html
@@ -41,21 +41,21 @@
     </p>
 
     <div class="release">
-      <a href="https://iojs.org/dist/v1.0.3/" class="release-logo-link">
+      <a href="https://iojs.org/dist/v1.0.4/" class="release-logo-link">
         <img class="release-logo" src="images/1.0.0.png" alt="io.js" />
       </a>
       <div class="release-details">
         <span class="release-version">
           <!-- Jan 13th 2015 -->
-          <a href="https://iojs.org/dist/v1.0.3/">Version 1.0.3 <em>(Unstable*)</em></a>
+          <a href="https://iojs.org/dist/v1.0.4/">Version 1.0.4 <em>(Unstable*)</em></a>
         </span>
         <br>
         <span class="release-downloads">
           Download for
-          <a href="https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-x64.tar.xz">Linux</a>,
-          <a href="https://iojs.org/dist/v1.0.3/iojs-v1.0.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.0.3/iojs-v1.0.3-x64.msi">Win64</a>,
+          <a href="https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-x64.tar.xz">Linux</a>,
+          <a href="https://iojs.org/dist/v1.0.4/iojs-v1.0.4-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.0.4/iojs-v1.0.4-x64.msi">Win64</a>,
           or
-          <a href="https://iojs.org/dist/v1.0.3/iojs-v1.0.3.pkg">Mac</a>.
+          <a href="https://iojs.org/dist/v1.0.4/iojs-v1.0.4.pkg">Mac</a>.
         </span>
         <br>
         <span class="release-changelog">


### PR DESCRIPTION
Updates io.js and V8 versions for v1.0.4 release.

cc/ @rvagg 