### PR TITLE
remove "unstable" messaging

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
       <div class="release-details">
         <span class="release-version">
           <!-- Jan 13th 2015 -->
-          <a href="https://iojs.org/dist/v1.0.4/">Version 1.0.4 <em>(Unstable*)</em></a>
+          <a href="https://iojs.org/dist/v1.0.4/">Version 1.0.4</a>
         </span>
         <br>
         <span class="release-downloads">
@@ -66,7 +66,7 @@
 
     <p class="lead">
       <a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.<br>
-      * Unstable? Learn more about <a href="/faq.html#version">how we version io.js</a>.
+      <a href="/faq.html">Frequently Asked Questions</a>
     </p>
   </div>
 


### PR DESCRIPTION
The word unstable was confusing in meaning and intent. This is arguably the most stable node release ever.

Fixes #108