### PR TITLE
Adds Danish translations of website

### DIFF
--- a/public/i18n/da/es6.html
+++ b/public/i18n/da/es6.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>io.js - ES6 i io.js</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="iojs">
+  <meta name="keywords" content="iojs, io.js, io js, javascript io, uv, libuv, node-forward, node forward, node, node.js, node.js forward, nodejs, nodejs forward, javascript">
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
+</head>
+
+  <body>
+
+  <header>
+    <div class="content">
+      <a href="/" class="logo">io.js</a>
+      <div class="spacer"></div>
+      <a href="faq.html">FAQ</a>
+      <a href="es6.html">ES6</a>
+      <a href="https://iojs.org/api/">API-dokumentation</a>
+    </div>
+  </header>
+
+  <div class="content">
+
+    <h1>ES6 i io.js</h1>
+
+    <div class="description">
+
+      <p>io.js er bygget op mod en moderne version af <a href="https://code.google.com/p/v8/">V8</a>. Ved at holde det opdateret med de seneste udgivelser af denne motor, sikrer vi at nye funktioner fra <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262-specifikationen</a> bliver rettidigt tilgængelige for io.js-udviklere, hvilket også gælder forbedringer til ydeevne og stabilitet.</p>
+      <p>Version 1.1.0 af io.js leveres med V8 4.1.0.14, som inkluderer ES6-funktioner et godt stykke forbi version 3.26.33, som vil blive leveret med joyent/node@0.12.x.</p>
+    </div>
+
+    <div class="faq-item">
+
+      <h2 class="faq-title">Ikke mere --harmony-flag</h2>
+      <div class="faq-body">
+        <p>I joyent/node@0.12.x (V8 3.26), slår <code>--harmony</code>-runtime-flaget alle <strong>færdige</strong>, <strong>staged</strong> og <strong>igangværende</strong> ES6-funktioner til sammen på samme tid (med undtagelse af ikke-standard/ikke-harmonerende semantikker for <code>typeof</code>, som blev skjult under <code>--harmony-typeof</code>). Dette betød at nogle meget fejlfyldte eller ikke-virkende funktioner som <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxy'er</a> var lige så tilgængelige for udviklere som <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generatorer</a>, der havde meget få eller endda ingen kendte problemer. Derfor var det den bedste praksis kun at slå bestemte funktioner til ved at bruge specifikke runtime-flag (fx <code>--harmony-generators</code>), eller ved simpelthen at slå dem alle til og derefter bruge et begrænset udsnit.</p>
+        <p>Med io.js@1.x (V8 4.1+) forsvinder al den kompleksitet. Alle harmoni-funktioner er nu logisk delt op i tre grupper for <strong>færdige</strong>, <strong>staged</strong> og <strong>igangværende</strong> funktioner:</p>
+
+        <ul class="task-list">
+    <li>Alle <strong>færdige</strong> funktioner, dem som V8 betragter som stabile, som <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generatorer</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings">skabeloner</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object">ny streng-metode</a> og mange andre er slået <strong>til som standard i io.js</strong> og kræver <strong>IKKE</strong> nogen form for runtime-flag. </li>
+    <li>Så er der <strong>staged</strong> funktioner, som er næsten-komplette funktioner, der ikke er fuldstændigt testede eller opdaterede til seneste specifikation endnu, og derfor ikke bliver betragtet som stabile af V8-teamet (fx kan der være grænsetilfælde, der ikke er fundet endnu). Det er formentlig tilsvarende status af <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generatorer</a> i 3.26. Disse er "brug på egen risiko"-typen af funktioner, der nu kræver runtime-flaget: <code>--es_staging</code> (eller dets synonym <code>--harmony</code>).</li>
+    <li>Som det sidste kan alle <strong>igangværende</strong> funktioner aktiveres individuelt med deres respektive harmoni-flag (fx <code>--harmony_arrow_functions</code>), selvom dette kraftigt frarådes udover til testing-formål.</li>
+    </ul>
+  </div>
+
+      <h2 class="faq-title">
+         Hvilke ES6-funktioner leveres med io.js som standard (ingen runtime-flag påkrævet)?
+      </h2>
+      <div class="faq-body">
+      <ul class="task-list">
+        <li>Block scoping</li>
+        <ul class="task-list">
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const">const</a></li>
+          <li><code>function</code>-in-blocks</a></li>
+        </ul>
+
+        <div class="note">
+          Fra v8 3.31.74.1, er block-scoped-deklarationer <a href="https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es">bevidst implementeret med en ikke-opfyldt begrænsning i forhold til strict-tilstandskode</a>. Udviklere bør være opmærksomme på, at dette vil ændre sig, mens v8 bevæger sig nærmere opfyldelse af ES6-specifikationen.
+        </div>
+
+        <li>Collections</li>
+        <ul class="task-list">
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map">Map</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap">WeakMap</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set">Set</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet">WeakSet</a></li>
+        </ul>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">Generators</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_literals">Binary and Octal literals</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promises</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object">New String methods</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol">Symbols</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings">Template strings</a></li>
+      </ul>
+
+      <p>You can view a more detailed list, including a comparison with other engines, on the <a href="https://kangax.github.io/compat-table/es6/">compat-table</a> project page.</p>
+    </div>
+    </div>
+
+    <div class="faq-item">
+      <h2 class="faq-title">
+         Hvis ES6-funktioner er gemt bag --es_staging-flaget?
+      </h2>
+      <div class="faq-body">
+        <ul class="task-list">
+          <li><a href="https://github.com/lukehoban/es6features#classes">Klasser</a> (kun strict-tilstand)</li>
+          <li><a href="https://github.com/lukehoban/es6features#enhanced-object-literals">Object literal extensions</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol"><code>Symbol.toStringTag</code></a> (brugerdefinerbare resultater for <code>Object.prototype.toString</code>)</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="faq-item">
+
+      <h2 class="faq-title">
+        Jeg har sat min infrastruktur op til at benytte sige af --harmony-flaget. Skal jeg fjerne det?
+      </h2>
+      <div class="faq-body">
+        <p>Den nuværende opførsel af <code>--harmony</code>-flaget i io.js har til formål kun at slå <strong>staged</strong>-funktioner til. Det er nu et synonym for <code>--es_staging</code>. Som nævnt ovenfor, så er det færdiggjorte funktioner, der ikke bliver betragtet som stabile endnu. Hvis du være på den sikre side, specielt i produktionsmiljøer, overvej at fjerne dette runtime-flag indtil det leveres som standard med V8 og derved også io.js. Hvis du vil beholde dette slået til, skal du være forberedt på at senere io.js-opgraderinger kan ødelægge din kode, hvis V8 ændrer deres semantik til at følge standarden tættere.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+
+      <h2 class="faq-title">
+         Hvordan finder jeg ud af hvilken version af V8, der leveres med en bestemt version af io.js?
+      </h2>
+      <div class="faq-body">
+        <p>io.js giver en simpel måde at liste alle dependencies og respektive versioner, der leveres med en specifik binary gennem det globale <code>process</code>-objekt. I forbindelse med V8-motoren, tast da det følgende ind i din terminal for at finde dens version:</p>
+        <div class="highlight highlight-sh"><pre>iojs -p process.versions.v8</span></pre></div>
+      </div>
+    </div>
+  </div>
+
+  <footer class="content">
+    <nav>
+      <a href="https://github.com/iojs/io.js/issues">GitHub-issues</a><!--
+   --><a href="https://github.com/iojs">GitHub-organisation</a><!--
+   --><a href="https://webchat.freenode.net/?channels=io.js">IRC-chat</a><!--
+   --><a href="http://logs.libuv.org/io.js/latest">Logs</a><!--
+   --><a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">Forvaltning</a>
+    </nav>
+  </footer>
+
+</body>
+
+</html>

--- a/public/i18n/da/faq.html
+++ b/public/i18n/da/faq.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>io.js - Ofte stillede spørgsmål</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="iojs">
+  <meta name="keywords" content="iojs, io.js, io js, javascript io, uv, libuv, node-forward, node forward, node, node.js, node.js forward, nodejs, nodejs forward, javascript">
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
+</head>
+
+<body>
+
+  <header>
+    <div class="content">
+      <a href="/" class="logo">io.js</a>
+      <div class="spacer"></div>
+      <a href="faq.html">FAQ</a>
+      <a href="es6.html">ES6</a>
+      <a href="https://iojs.org/api/">API-dokumentation</a>
+    </div>
+  </header>
+
+  <div class="content">
+
+    <h1 class="heading">Ofte stillede spørgsmål</h1>
+
+    <h2 id="what-is-io-js">Hvad er io.js?</h2>
+    <p><a href="https://github.com/iojs/io.js">io.js</a> er en JavaScript-platform bygget på <a href="http://code.google.com/p/v8/">Chromes V8-runtime</a>. Dette projekt startede som en fork af <a href="https://nodejs.org/">Joyents Node.js™</a> og er kompatibelt med <a href="https://www.npmjs.org/">npm</a>-økosystemet.</p>
+    <p>Hvorfor? io.js stiler efter at give hurtigere og mere forudsigelige udgivelsescyklusser. Det inkluderer på nuværende tidspunkt de seneste sprog-, API- og ydeevne-forbedringer til V8, mens også libuv og andre grundbiblioteker er opdateret.</p>
+    <p>Dette projekt stiler efter at fortsætte udvikling af io.js under en "<a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">åben forvaltningsmodel</a>" modsat virksomhedsforvaltning.</p>
+
+    <h2 id="version">Version 1.0.x?</h2>
+    <p>io.js er ændret til <a href="http://semver.org/">Semver</a> og ændringer mellem Node.js™ 0.10 og io.js 1.0.0 er betydeligt nok til at kræve en forøgelse til næste større version.</p>
+    <p>Vores <a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">CHANGELOG</a> for v1.x giver en <a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#summary-of-changes-from-nodejs-v01035-to-iojs-v100">oversigt over ændringerne fra Node.js v0.10.35 til io.js v1.0.x</a>.</p>
+
+    <h2>
+      Hvordan kan jeg bidrage?
+    </h2>
+    <p>
+      Alle kan hjælpe.
+      io.js holder sig til et <a href="https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct">adfærdskodeks</a>, og bidrag og udgivelser er underlagt en <a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">åben forvaltningsmodel</a>.
+    </p>
+    <p>
+      For at komme igang, er der åbne <a href="https://github.com/iojs/io.js/issues"> diskussioner på GitHub</a> og vi vil meget gerne høre dine tilbagemeldinger.
+      At blive en del af diskussioner er en god måde at få føling for, hvordan du kan hjælpe yderligere til. Hvis der er noget der, du føler, du kan håndtere, så <a href="https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-contributions">lav venligst en pull request</a>.
+
+
+      Udover det, er det at bruge <a href="http://nodebug.me/">Nodebug.me</a> en god måde at hjælpe med at vurdere vigtigheden af eksisterende issues.
+    </p>
+
+    <h2>
+      Hvor finder diskussioner sted?
+    </h2>
+    <p>
+      Der er en #io.js-kanal på Freenode IRC. Vi holder logs fra kanalen <a target="_blank" href="http://logs.libuv.org/io.js/latest">her</a>.
+    </p>
+
+
+    <h2>
+      Hvad er open source-forvaltning?
+    </h2>
+    <p>
+      Open source-forvaltning taler for at bruge filosifierne fra open source- og open content-bevægelser for at give enhver interesseret part mulighed for at tilføje til skabelsen af slutproduktet, så vel som et wiki-dokument. Lovgivning er demokratisk åbnet op for generelle borgere, der bruger deres kollektive viden til at fordel for beslutningsprocessen og for at forbedre demokratiet. <a href="https://en.wikipedia.org/wiki/Open-source_governance" target="_blank">[kilde på engelsk]</a>
+    </p>
+
+  </div>
+
+  <footer class="content">
+    <nav>
+      <a href="https://github.com/iojs/io.js/issues">GitHub-issues</a><!--
+   --><a href="https://github.com/iojs">GitHub-organisation</a><!--
+   --><a href="https://webchat.freenode.net/?channels=io.js">IRC-chat</a><!--
+   --><a href="http://logs.libuv.org/io.js/latest">Logs</a><!--
+   --><a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">Forvaltning</a>
+    </nav>
+  </footer>
+
+</body>
+
+</html>

--- a/public/i18n/da/index.html
+++ b/public/i18n/da/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>io.js - JavaScript I/O</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="io.js er en npm-kompatibel platform oprindeligt baseret på node.js">
+  <meta name="keywords" content="iojs, io.js, io js, javascript io, uv, libuv, node-forward, node forward, node, node.js, node.js forward, nodejs, nodejs forward, javascript">
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
+  <link rel="icon" href="/images/1.0.0.ico" type="image/x-icon">
+  <link rel="apple-touch-icon" href="/images/apple-touch-icon-1.0.0.png">
+  <meta property="og:image" content="https://iojs.org/images/1.0.0.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1369">
+  <meta property="og:image:height" content="1563">
+</head>
+
+<body>
+
+  <header>
+    <div class="content">
+      <a href="/" class="logo">io.js</a>
+      <div class="spacer"></div>
+      <a href="faq.html">FAQ</a>
+      <a href="es6.html">ES6</a>
+      <a href="https://iojs.org/api/">API-dokumentation</a>
+    </div>
+  </header>
+
+  <div class="content">
+    <h1>JavaScript I/O</h1>
+
+    <p class="lead">
+      Bringer <a href="es6.html">ES6</a> til Node-folket!
+    </p>
+    <p class="lead">
+      <a href="https://github.com/iojs/io.js">io.js</a> er en <a href="https://www.npmjs.org/">npm</a>-kompatibel platform oprindeligt baseret på <a href="https://nodejs.org/">node.js</a>&#8482;.
+    </p>
+
+    <div class="release">
+      <a href="https://iojs.org/dist/v1.1.0/" class="release-logo-link">
+        <img class="release-logo" src="images/1.0.0.png" alt="io.js" />
+      </a>
+      <div class="release-details">
+        <span class="release-version">
+          <!-- Jan 13th 2015 -->
+          <a href="https://iojs.org/dist/v1.1.0/">Version 1.1.0</a>
+        </span>
+        <br>
+        <span class="release-downloads">
+          Download til
+          <a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.xz">Linux</a>,
+          <a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi">Win64</a>
+          eller
+          <a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg">Mac</a>.
+        </span>
+        <br>
+        <span class="release-changelog">
+          <a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a>
+        </span>
+      </div>
+    </div>
+
+    <p class="lead">
+      <a href="https://iojs.org/download/nightly/">Natlige udgivelser</a> er tilgængelige til testing.<br>
+      <a href="/faq.html">Ofte stillede spørgsmål</a>
+    </p>
+  </div>
+
+  <footer class="content">
+    <nav>
+      <a href="https://github.com/iojs/io.js/issues">GitHub-issues</a><!--
+   --><a href="https://github.com/iojs">GitHub-organisation</a><!--
+   --><a href="https://webchat.freenode.net/?channels=io.js">IRC-chat</a><!--
+   --><a href="http://logs.libuv.org/io.js/latest">Logs</a><!--
+   --><a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">Forvaltning</a>
+    </nav>
+  </footer>
+
+<!-- Ser du noget, du kan lide? Vil du hjælpe? Besøg https://github.com/iojs/website for at bidrage  -->
+</body>
+
+</html>


### PR DESCRIPTION
Input from another Danish native would probably be preferable before this should be merged, but everything has been translated except specific words deemed untranslatable.

This includes "runtime", "staged" and "dependencies" which have no apparent Danish translations that makes sense in a programming context.
