### PR TITLE
add 'others' link to front page

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -10,9 +10,10 @@ Bringing [ES6](es6.html) to the Node Community!
 
 Download for
 [Linux](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.xz),
-[Win32](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi), [Win64](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi),
-or
-[Mac](https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg).
+[Win32](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi),
+[Win64](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi),
+[Mac](https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg) or
+[others](https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg).
 
 
 [Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)


### PR DESCRIPTION
Right now, Windows .exe builds and ARMv7 aren't linked to from the front page. This commit adds a link to the directory containing all release build files, making them easier to find.
