### PR TITLE
[build/gulpjs] Make quotes consistent

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,30 +1,30 @@
-var dest = "./public";
+var dest = './public';
 var src = './source';
 var content = './content';
 
 module.exports = {
   stylus: {
-    src: src + "/styles/**/*.styl",
+    src: src + '/styles/**/*.styl',
     dest: dest,
     settings: {
       // put stylus settings here
     }
   },
   templates: {
-    templateSrc: src + "/templates/**/*.html",
-    contentSrc: content + "/**/*.md",
-    templateJSONsrc: content + "/**/template.json",
+    templateSrc: src + '/templates/**/*.html',
+    contentSrc: content + '/**/*.md',
+    templateJSONsrc: content + '/**/template.json',
     dest: dest
   },
   images: {
-    src: dest + "/img/**",
-    dest: dest + "/img"
+    src: dest + '/img/**',
+    dest: dest + '/img'
   },
   del: {
     files: [
-      dest + "/**/*.html",
-      dest + "/**/*.js",
-      dest + "/**/*.css",
+      dest + '/**/*.html',
+      dest + '/**/*.js',
+      dest + '/**/*.css',
       '!'+ dest + '/index.html',
       '!'+ dest + '/es6.html',
       '!'+ dest + '/faq.html',

--- a/gulp/tasks/minifyCss.js
+++ b/gulp/tasks/minifyCss.js
@@ -13,7 +13,7 @@ gulp.task('minifyCss', function() {
       csswring
     ]))
     .pipe(rename(function(path){
-      path.extname = ".min.css";
+      path.extname = '.min.css';
     }))
     .pipe(gulp.dest(config.dest))
     .pipe(size());

--- a/gulp/util/handleErrors.js
+++ b/gulp/util/handleErrors.js
@@ -1,4 +1,4 @@
-var notify = require("gulp-notify");
+var notify = require('gulp-notify');
 
 module.exports = function() {
 
@@ -6,8 +6,8 @@ module.exports = function() {
 
   // Send error to notification center with gulp-notify
   notify.onError({
-    title: "Compile Error",
-    message: "<%= error %>"
+    title: 'Compile Error',
+    message: '<%= error %>'
   }).apply(this, args);
 
   // Keep gulp from hanging on this task


### PR DESCRIPTION
- change double quotes to single quotes in the gulp task scripts, to be consistent