### PR TITLE
update faq.html

### DIFF
--- a/public/faq.html
+++ b/public/faq.html
@@ -31,7 +31,9 @@
     <h2 id="what-is-io-js">What is io.js?</h2>
     <p><a href="https://github.com/iojs/io.js">io.js</a> is a JavaScript platform built on <a href="http://code.google.com/p/v8/">Chrome's V8 runtime</a>. This project began as a fork of <a href="https://nodejs.org/">Joyent's Node.js™</a> and is compatible with
       the <a href="https://www.npmjs.org/">npm</a> ecosystem.</p>
-    <p>Why? io.js aims to provide faster and predictable release cycles. It currently merges in the latest language, API and performance improvements to V8 while also updating libuv and other base libraries.</p>
+      
+    <h2 id="why-io-js">Why?</h2>
+    <p>io.js aims to provide faster and predictable release cycles. It currently merges in the latest language, API and performance improvements to V8 while also updating libuv and other base libraries.</p>
     <p>This project aims to continue development of io.js under an "<a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">open governance model</a>" as opposed to corporate stewardship.</p>
 
     <h2 id="version">Version 1.0.x?</h2>


### PR DESCRIPTION
On the FAQ page I think it would be worth giving the "Why" section it's own header as it is currently sitting within the "What" part. Some issues seem to be related to finding or making more clear the Why behind the fork and I think giving this section it's own header would help here.

The Why behind the fork is also presumably a frequently asked question and therefore deserves its own callout.

Here is what it currently looks like:

![current_iojs_site](https://cloud.githubusercontent.com/assets/5756226/6109766/293c8d88-b075-11e4-8a1d-dc43a17e89f6.png)

If we add the Why header:

![possible_iojs_site](https://cloud.githubusercontent.com/assets/5756226/6109772/2e37afd4-b075-11e4-96cb-2d61fe9cee85.png)