### PR TITLE
Completed Traditional Chinese Translation for zh_TW (Taiwan)

### DIFF
--- a/content/zh_TW/es6.md
+++ b/content/zh_TW/es6.md
@@ -1,0 +1,69 @@
+# ES6 on io.js
+
+io.js is built against modern versions of [V8](https://code.google.com/p/v8/). By keeping up-to-date with the latest releases of this engine we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.
+
+Version 1.1.0 of io.js ships with V8 4.1.0.14, which includes ES6 features well beyond version 3.28.73 that ship with Node.js™ 0.12.x.
+
+## No more --harmony flag
+
+On Node.js™@0.12.x (V8 3.28+), the `--harmony` runtime flag enables all **completed**, **staged** and **in progress** ES6 features together, in bulk (with the exception of `proxies` which are hidden under `--harmony-proxies`). This means that some really buggy or even broken features like [Arrow Functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) are just as readily available for developers as [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), which have very little or even no known-issues. As such, most developers tend to enable only certain features by using specific runtime harmony feature flags (e.g. `--harmony-generators`), or simply enable all of them and then use a restricted subset.
+
+With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for **shipping**, **staged** and **in progress** features:
+
+*   All **shipping** features, the ones that V8 has considered stable, like [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), [templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings), [new string methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object) and many others are turned **on by default on io.js** and do **NOT** require any kind of runtime flag.
+*   Then there are **staged** features which are almost-completed features that haven't been completely tested or updated to the latest spec yet and therefore are not considered stable by the V8 team (e.g. there might be some edge cases left to discover). This is probably the equivalent of the state of [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) on 3.26. These are the "use at your own risk" type of features that now require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
+*   Finally, all **in progress** features can be activated individually by their respective harmony flag (e.g. `--harmony_arrow_functions`), although this is highly discouraged unless for testing purposes.
+
+## Which ES6 features ship with io.js by default (no runtime flag required)?
+
+
+*   Block scoping
+
+    *   [let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
+
+    *   [const](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const)
+
+    *   `function`-in-blocks
+
+    >As of v8 3.31.74.1, block-scoped declarations are [intentionally implemented with a non-compliant limitation to strict mode code](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Developers should be aware that this will change as v8 continues towards ES6 specification compliance.
+
+*   Collections
+
+    *   [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+
+    *   [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap)
+
+    *   [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
+
+    *   [WeakSet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet)*   [Generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*)
+
+*   [Binary and Octal literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_literals)
+
+*   [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+
+*   [New String methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object)
+
+*   [Symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
+
+*   [Template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings)
+
+You can view a more detailed list, including a comparison with other engines, on the [compat-table](https://kangax.github.io/compat-table/es6/) project page.
+
+## Which ES6 features are behind the --es_staging flag?
+
+*   [Classes](https://github.com/lukehoban/es6features#classes) (strict mode only)
+*   [Object literal extensions](https://github.com/lukehoban/es6features#enhanced-object-literals)
+
+*   [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) (user-definable results for `Object.prototype.toString`)
+
+## I have my infrastructure set up to leverage the --harmony flag. Should I remove it?
+
+The current behaviour of the `--harmony` flag on io.js is to enable **staged** features only. After all, it is now a synonym of `--es_staging`. As mentioned above, these are completed features that have not been considered stable yet. If you want to play safe, especially on production environments, consider removing this runtime flag until it ships by default on V8 and, consequently, on io.js. If you keep this enabled, you should be prepared for further io.js upgrades to break your code if V8 changes their semantics to more closely follow the standard.
+
+## How do I find which version of V8 ships with a particular version of io.js?
+
+io.js provides a simple way to list all dependencies and respective versions that ship with a specific binary through the `process` global object. In case of the V8 engine, type the following in your terminal to retrieve its version:
+
+```sh
+iojs -p process.versions.v8
+```

--- a/content/zh_TW/es6.md
+++ b/content/zh_TW/es6.md
@@ -1,20 +1,20 @@
-# ES6 on io.js
+# io.js 的 ES6
 
-io.js is built against modern versions of [V8](https://code.google.com/p/v8/). By keeping up-to-date with the latest releases of this engine we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.
+io.js 建構於目前版本的 [V8](https://code.google.com/p/v8/) 之上，將會持續更新並引入最新的引擎版本，以確保最新的 [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) 特性能以最短的時間內被 io.js 的開發人員所使用，並藉著不斷快速更新此持續改善效能及穩定度。
 
-Version 1.1.0 of io.js ships with V8 4.1.0.14, which includes ES6 features well beyond version 3.28.73 that ship with Node.js™ 0.12.x.
+目前釋出的 io.js v1.1.0 版本已採用 V8 4.1.0.14，其支援的 ES6 特性遠超過 joyent/node@0.12.x 所使用的 V8 3.26.23 。
 
-## No more --harmony flag
+## 不再需要 --harmony 參數
 
-On Node.js™@0.12.x (V8 3.28+), the `--harmony` runtime flag enables all **completed**, **staged** and **in progress** ES6 features together, in bulk (with the exception of `proxies` which are hidden under `--harmony-proxies`). This means that some really buggy or even broken features like [Arrow Functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) are just as readily available for developers as [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), which have very little or even no known-issues. As such, most developers tend to enable only certain features by using specific runtime harmony feature flags (e.g. `--harmony-generators`), or simply enable all of them and then use a restricted subset.
+在 joyent/node@0.12.x (V8 3.26) 上，參數 `--harmony` 將會一次啟用所有處於**完成（completed）**、**階段性（staged）**及**程序中（in progress）**狀態之下的 ES6 特性支援（除了 `proxies` ，此特性在使用參數 `--harmony-proxies` 時會被隱藏）。這意味著一些臭蟲或是很有問題的特性像是 [Arrow Functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) ，可能將會很容易的被開發人員所誤用在專案中，就如同沒有問題的特性 `generators` 一般。因此，大多數的開發人員通常會代入一些參數，只啟動特定的 harmony 特性支援（如：`--harmony-generators`），或是直接啟用所有的特性支援，然後在開發時限定只使用特定某些穩定的功能。
 
-With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for **shipping**, **staged** and **in progress** features:
+不過在使用 io.js@1.x (V8 4.1+) 之後，前面所提到的所有麻煩將不再是問題。現在所有的 harmony 特性都將會被分類到不同的群組中，分別為 **shipping** 、 **staged** 和 **in progress**：
 
-*   All **shipping** features, the ones that V8 has considered stable, like [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), [templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings), [new string methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object) and many others are turned **on by default on io.js** and do **NOT** require any kind of runtime flag.
-*   Then there are **staged** features which are almost-completed features that haven't been completely tested or updated to the latest spec yet and therefore are not considered stable by the V8 team (e.g. there might be some edge cases left to discover). This is probably the equivalent of the state of [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) on 3.26. These are the "use at your own risk" type of features that now require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
-*   Finally, all **in progress** features can be activated individually by their respective harmony flag (e.g. `--harmony_arrow_functions`), although this is highly discouraged unless for testing purposes.
+*   所有屬於 **shipping** 群組的特性，都是被 V8 認定為穩定（stable）的功能，如：[generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) 、 [templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings) 、 [new string methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object) 。值得一提的是，現在屬於此群組的更多特性都將被 **預設啟用於 io.js** ，且**不需要**在執行時添加使用任何參數。
+*   那些被歸類為 **staged** 群組的特性，都是功能上幾乎已經完整支援（almost-completed）的特性，但缺少測試或尚未支援到最新的 ES6 規格，所以尚未被 V8 的開發團隊視為穩定（stable）。這些特性的支援可能相當於 V8 3.26 時的 [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) ，如果要使用，開發人員必須要自行承擔其風險，而且必須要在執行時使用 `--es_staging` 參數（同等於 `--harmony`）。
+*   最後，所有處於 **in progress** 群組的特性，可以以特定的參數啟用支援（如：`--harmony_arrow_functions`，儘管這些特性不被推薦使用。
 
-## Which ES6 features ship with io.js by default (no runtime flag required)?
+## 什麼樣的 ES6 特性將被 io.js 預設支援？（不需要代入任何參數）
 
 
 *   Block scoping
@@ -47,22 +47,22 @@ With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features ar
 
 *   [Template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings)
 
-You can view a more detailed list, including a comparison with other engines, on the [compat-table](https://kangax.github.io/compat-table/es6/) project page.
+你可以參閱更多的細節，以及比較其他的 JavaScript 引擎，在 [compat-table](https://kangax.github.io/compat-table/es6/) 專案網頁。
 
-## Which ES6 features are behind the --es_staging flag?
+## 什麼樣的 ES6 特性需要代入 --es_staging 參數？
 
-*   [Classes](https://github.com/lukehoban/es6features#classes) (strict mode only)
+*   [Classes](https://github.com/lukehoban/es6features#classes) 只有嚴格模式支援）
 *   [Object literal extensions](https://github.com/lukehoban/es6features#enhanced-object-literals)
 
 *   [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) (user-definable results for `Object.prototype.toString`)
 
-## I have my infrastructure set up to leverage the --harmony flag. Should I remove it?
+## 我過去已經大量使用了 --harmony 參數，我該移除它嗎？
 
-The current behaviour of the `--harmony` flag on io.js is to enable **staged** features only. After all, it is now a synonym of `--es_staging`. As mentioned above, these are completed features that have not been considered stable yet. If you want to play safe, especially on production environments, consider removing this runtime flag until it ships by default on V8 and, consequently, on io.js. If you keep this enabled, you should be prepared for further io.js upgrades to break your code if V8 changes their semantics to more closely follow the standard.
+目前 `--harmony` 在 io.js 的行為，只會啟用 **staged** 的特性，與 `--es_staging` 參數相同。如前面所提及，這些都是些尚未被視為穩定的特性，如果你想要更安全的使用 io.js ，尤其特別是在已上線的服務或產品上使用，請考慮移除並停止使用此參數，直到這些特性被 V8 所預設支援，接著被 io.js 所支援。假設你仍然持續使用這個參數，你可能要有因為升級 io.js 而導致程式壞掉的心理準備，尤其是如果 V8 為了更接近標準而修改語法，就會出現這樣的問題。
 
-## How do I find which version of V8 ships with a particular version of io.js?
+## 我如何得知 io.js 正在使用的 V8 版本？
 
-io.js provides a simple way to list all dependencies and respective versions that ship with a specific binary through the `process` global object. In case of the V8 engine, type the following in your terminal to retrieve its version:
+io.js 提供了一個非常簡單的方法去取得所有的依賴函式庫及版本號，只要透過存取 `process` 全域物件即可。所以，如果想知道 V8 引擎的版本資訊，可以直接在終端機（Terminal）上輸入：
 
 ```sh
 iojs -p process.versions.v8

--- a/content/zh_TW/faq.md
+++ b/content/zh_TW/faq.md
@@ -1,0 +1,36 @@
+# FAQ
+
+## What is io.js?
+
+[io.js](https://github.com/iojs/io.js) is a JavaScript platform built on [Chrome's V8 runtime](http://code.google.com/p/v8/). This project began as a fork of [Joyent's Node.js™](https://nodejs.org/) and is compatible with the [npm](https://www.npmjs.org/) ecosystem.
+
+## Why? 
+
+io.js aims to provide faster and predictable release cycles. It currently merges in the latest language, API and performance improvements to V8 while also updating libuv and other base libraries.
+
+This project aims to continue development of io.js under an "[open governance model](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme)" as opposed to corporate stewardship.
+
+## Version 1.0.x?
+
+io.js has moved to [Semver](http://semver.org/) and the changes between Node.js™ 0.10 and io.js 1.0.0 were significant enough
+to warrant a major version increment.
+
+Our [CHANGELOG](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md) for v1.x provides a [summary of changes from Node.js v0.10.35 to io.js v1.0.x](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#summary-of-changes-from-nodejs-v01035-to-iojs-v100).
+
+## How can I contribute?
+
+Everyone can help. io.js adheres to a [code of conduct](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct), and contributions, releases, and contributorship are under an [open governance](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme) model.
+
+To get started, there are open [ discussions on GitHub](https://github.com/iojs/io.js/issues), and we'd love to hear your feedback.
+Becoming involved in discussions is a good way to get a feel of where you can help out further. If there is
+something there you feel you can tackle, please [make a pull request](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-contributions).
+
+In addition, using [Nodebug.me](http://nodebug.me/) is a good way to help Triage the issues in the backlog.
+
+## Where do discussions take place?
+
+There is an #io.js channel on Freenode IRC. We keep logs of the channel [here](http://logs.libuv.org/io.js/latest).
+
+## What is open source governance?
+
+Open source governance advocates the application of the philosophies of the open source and open content movements in order to enable any interested party to add to the creation of the end product, as with a wiki document. Legislation is democratically opened to the general citizenry, employing their collective wisdom to benefit the decision-making process and improve democracy. [[source]](https://en.wikipedia.org/wiki/Open-source_governance)

--- a/content/zh_TW/faq.md
+++ b/content/zh_TW/faq.md
@@ -1,36 +1,33 @@
-# FAQ
+# 常見問題（FAQ）
 
-## What is io.js?
+## 什麼是 io.js ？
 
-[io.js](https://github.com/iojs/io.js) is a JavaScript platform built on [Chrome's V8 runtime](http://code.google.com/p/v8/). This project began as a fork of [Joyent's Node.js™](https://nodejs.org/) and is compatible with the [npm](https://www.npmjs.org/) ecosystem.
+[io.js](https://github.com/iojs/io.js) 是一個以 [Chrome's V8 runtime](http://code.google.com/p/v8/) 為基礎的 JavaScript 應用程式開發平台，這個專案一開始是從 [Joyent's Node.js™](https://nodejs.org/) 分支出來的一個版本，完全與  [npm](https://www.npmjs.org/) 相容。
 
-## Why? 
+## 為什麼這麼做呢？
 
-io.js aims to provide faster and predictable release cycles. It currently merges in the latest language, API and performance improvements to V8 while also updating libuv and other base libraries.
+io.js 目標將提供更快速且可預期的釋出週期，目前已經整合了最新的語言特性、 API 以及 V8 的效能改進，此外也更新了 libuv 與其他的基礎函式庫。
 
-This project aims to continue development of io.js under an "[open governance model](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme)" as opposed to corporate stewardship.
+這個專案目標將以『[開放管理模式（open governance model）](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme)』持續進行維護與開發，不同於被特定公司所主導發展的營運方式。
 
-## Version 1.0.x?
+## 版本 1.0.x？
 
-io.js has moved to [Semver](http://semver.org/) and the changes between Node.js™ 0.10 and io.js 1.0.0 were significant enough
-to warrant a major version increment.
+io.js 的改進與版本更新將遵守[語意化版本控制規範（Semver）](http://semver.org/)，我們認為目前專案的發展狀況，完全有足夠的理由提升主版本號，使專案從 Node.js™ 0.10 到 io.js 1.0.0 版本。
 
-Our [CHANGELOG](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md) for v1.x provides a [summary of changes from Node.js v0.10.35 to io.js v1.0.x](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#summary-of-changes-from-nodejs-v01035-to-iojs-v100).
+我們的 v1.x 版本的[更新日誌](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)將提供[從 Node.js v0.10.35 到 io.js v1.0.x 版本的變更說明](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#summary-of-changes-from-nodejs-v01035-to-iojs-v100)。
 
-## How can I contribute?
+## 我如何能貢獻？
 
-Everyone can help. io.js adheres to a [code of conduct](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct), and contributions, releases, and contributorship are under an [open governance](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme) model.
+任何人都可以給予這個專案幫助，io.js 遵守[行為準則（code of conduct）](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct)且接受不違反[開放管理模式（open governance model）](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme)下的任何貢獻、釋出及貢獻關係。
 
-To get started, there are open [ discussions on GitHub](https://github.com/iojs/io.js/issues), and we'd love to hear your feedback.
-Becoming involved in discussions is a good way to get a feel of where you can help out further. If there is
-something there you feel you can tackle, please [make a pull request](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-contributions).
+一開始，可以在[discussions on GitHub](https://github.com/iojs/io.js/issues)進行公開討論，我們非常樂意聽到您的意見回饋。 加入並參與各種討論是一個找到能貢獻之處的好方法，如果你找到一個自己可以幫得上忙的事，請直接[建立一個 pull request](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-contributions)。
 
-In addition, using [Nodebug.me](http://nodebug.me/) is a good way to help Triage the issues in the backlog.
+此外，使用[Nodebug.me](http://nodebug.me/) 是一個協助社群指派分配任務的好方法。
 
-## Where do discussions take place?
+## 哪裡是一個進行討論的好地方？
 
-There is an #io.js channel on Freenode IRC. We keep logs of the channel [here](http://logs.libuv.org/io.js/latest).
+Freenode IRC 的 #io.js 頻道是一個可以進行討論的地方，我們將保存該頻道的討論紀錄[在這](http://logs.libuv.org/io.js/latest)。
 
-## What is open source governance?
+## 什麼是開放原始碼管理？
 
-Open source governance advocates the application of the philosophies of the open source and open content movements in order to enable any interested party to add to the creation of the end product, as with a wiki document. Legislation is democratically opened to the general citizenry, employing their collective wisdom to benefit the decision-making process and improve democracy. [[source]](https://en.wikipedia.org/wiki/Open-source_governance)
+開源管理方式引入開放原始碼的哲學以及開放內容運動，讓各個有興趣的團體對最終產品做出貢獻。其決策程序對於一般公民開放，就能夠以眾人的智慧來改善決策、深化參與。 [參考連結](https://en.wikipedia.org/wiki/Open-source_governance)

--- a/content/zh_TW/index.md
+++ b/content/zh_TW/index.md
@@ -1,0 +1,23 @@
+# JavaScript I/O
+
+Bringing [ES6](es6.html) to the Node Community!
+
+[io.js](https://github.com/iojs/io.js) is an [npm](https://www.npmjs.org/) compatible platform originally based on [node.js](https://nodejs.org/)&#8482;.
+
+[![io.js](../images/1.0.0.png)](https://iojs.org/dist/v1.1.0/)
+
+[Version 1.1.0](https://iojs.org/dist/v1.1.0/)
+
+Download for
+[Linux](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.xz),
+[Win32](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi),
+[Win64](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi),
+[Mac](https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg) or
+[others](https://iojs.org/dist/v1.1.0/).
+
+
+[Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
+
+[Nightly releases](https://iojs.org/download/nightly/) are available for testing.
+
+[Frequently Asked Questions](/faq.html)

--- a/content/zh_TW/index.md
+++ b/content/zh_TW/index.md
@@ -1,14 +1,14 @@
 # JavaScript I/O
 
-Bringing [ES6](es6.html) to the Node Community!
+讓 [ES6](es6.html) 走入 Node.js 社群！
 
-[io.js](https://github.com/iojs/io.js) is an [npm](https://www.npmjs.org/) compatible platform originally based on [node.js](https://nodejs.org/)&#8482;.
+[io.js](https://github.com/iojs/io.js) 是一個與 [npm](https://www.npmjs.org/) 相容並以 [node.js](https://nodejs.org/)&#8482; 為基礎的應用程式平台。
 
 [![io.js](../images/1.0.0.png)](https://iojs.org/dist/v1.1.0/)
 
-[Version 1.1.0](https://iojs.org/dist/v1.1.0/)
+[目前版本 1.1.0](https://iojs.org/dist/v1.1.0/)
 
-Download for
+下載各種平台版本
 [Linux](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.xz),
 [Win32](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi),
 [Win64](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi),
@@ -16,8 +16,8 @@ Download for
 [others](https://iojs.org/dist/v1.1.0/).
 
 
-[Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
+[更新日誌](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
 
-[Nightly releases](https://iojs.org/download/nightly/) are available for testing.
+每天定時釋出的 [Nightly releases](https://iojs.org/download/nightly/) 版本開放測試！
 
-[Frequently Asked Questions](/faq.html)
+[常見問與答](/faq.html)

--- a/content/zh_TW/template.json
+++ b/content/zh_TW/template.json
@@ -4,8 +4,8 @@
   "faq-link":"常見問題",
   "es6-link":"ES6",
   "api-link":"API 文件",
-  "issues-link":"GitHub Issues",
-  "org-link":"GitHub Org",
+  "issues-link":"GitHub 議題",
+  "org-link":"GitHub 組織",
   "irc-link":"IRC 討論",
   "irc-logs-link":"日誌",
   "gov-link":"專案管理"

--- a/content/zh_TW/template.json
+++ b/content/zh_TW/template.json
@@ -1,0 +1,12 @@
+{
+  "browser-title":"io.js - JavaScript I/O",
+  "logo-text":"io.js",
+  "faq-link":"常見問題",
+  "es6-link":"ES6",
+  "api-link":"API 文件",
+  "issues-link":"GitHub Issues",
+  "org-link":"GitHub Org",
+  "irc-link":"IRC 討論",
+  "irc-logs-link":"日誌",
+  "gov-link":"專案管理"
+}


### PR DESCRIPTION
Completed Traditional Chinese Translation for zh_TW (Taiwan).

BTW, Chinese language has two types(Simple and Traditional), depending on region of users. It should use localization rule like zh_CN, zh_TW and zh_HK to specify what is exact type for user, not just `cn`.