### PR TITLE
Adds Danish translation of website

### DIFF
--- a/content/da/es6.md
+++ b/content/da/es6.md
@@ -1,20 +1,20 @@
-# ES6 on io.js
+# ES6 i io.js
 
-io.js is built against modern versions of [V8](https://code.google.com/p/v8/). By keeping up-to-date with the latest releases of this engine we ensure new features from the [JavaScript ECMA-262 specification](http://www.ecma-international.org/publications/standards/Ecma-262.htm) are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.
+io.js er bygget op mod en moderne version af [V8](https://code.google.com/p/v8/). Ved at holde det opdateret med de seneste udgivelser af denne motor, sikrer vi at nye funktioner fra [JavaScript ECMA-262-specifikationen](http://www.ecma-international.org/publications/standards/Ecma-262.htm) bliver rettidigt tilgængelige for io.js-udviklere, hvilket også gælder forbedringer til ydeevne og stabilitet.
 
-Version 1.1.0 of io.js ships with V8 4.1.0.14, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.
+Version 1.1.0 af io.js leveres med V8 4.1.0.14, som inkluderer ES6-funktioner et godt stykke forbi version 3.26.33, som vil blive leveret med joyent/node@0.12.x.
 
-## No more --harmony flag
+## Ikke mere --harmony-flag
 
-On joyent/node@0.12.x (V8 3.26), the `--harmony` runtime flag enabled all **completed**, **staged** and **in progress** ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for `typeof` which were hidden under `--harmony-typeof`). This meant that some really buggy or even broken features like [proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) were just as readily available for developers as [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. `--harmony-generators`), or simply enable all of them and then use a restricted subset.
+I joyent/node@0.12.x (V8 3.26), slår `--harmony`-runtime-flaget alle **færdige**, **staged** og **igangværende** ES6-funktioner til sammen på samme tid (med undtagelse af ikke-standard/ikke-harmonerende semantikker for `typeof`, som blev skjult under `--harmony-typeof`). Dette betød at nogle meget fejlfyldte eller ikke-virkende funktioner som [proxy'er](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) var lige så tilgængelige for udviklere som [generatorer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), der havde meget få eller endda ingen kendte problemer. Derfor var det den bedste praksis kun at slå bestemte funktioner til ved at bruge specifikke runtime-flag (fx `--harmony-generators`), eller ved simpelthen at slå dem alle til og derefter bruge et begrænset udsnit.
 
-With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for **shipping**, **staged** and **in progress** features:
+Med io.js@1.x (V8 4.1+) forsvinder al den kompleksitet. Alle harmoni-funktioner er nu logisk delt op i tre grupper for **færdige**, **staged** og **igangværende** funktioner:
 
-*   All **shipping** features, the ones that V8 has considered stable, like [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), [templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings), [new string methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object) and many others are turned **on by default on io.js** and do **NOT** require any kind of runtime flag.
-*   Then there are **staged** features which are almost-completed features that haven't been completely tested or updated to the latest spec yet and therefore are not considered stable by the V8 team (e.g. there might be some edge cases left to discover). This is probably the equivalent of the state of [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) on 3.26. These are the "use at your own risk" type of features that now require a runtime flag: `--es_staging` (or its synonym, `--harmony`).
-*   Finally, all **in progress** features can be activated individually by their respective harmony flag (e.g. `--harmony_arrow_functions`), although this is highly discouraged unless for testing purposes.
+*   Alle **færdige** funktioner, dem som V8 betragter som stabile, som [generatorer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*), [skabeloner](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings), [ny streng-methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object) og mange andre er slået **til som standard i io.js** og kræver **IKKE** nogen form for runtime-flag.
+*   Så er der **staged** funktioner, som er næsten-komplette funktioner, der ikke er fuldstændigt testede eller opdaterede til seneste specifikation endnu, og derfor ikke bliver betragtet som stabile af V8-teamet (fx kan der være grænsetilfælde, der ikke er fundet endnu). Det er formentlig tilsvarende status af [generatorer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) i 3.26. Disse er "brug på egen risiko"-typen af funktioner, der nu kræver runtime-flaget: `--es_staging` (eller dets synonym `--harmony`).
+*   Som det sidste kan alle **igangværende** funktioner aktiveres individuelt med deres respektive harmoni-flag (fx `--harmony_arrow_functions`), selvom dette kraftigt frarådes udover til testing-formål.
 
-## Which ES6 features ship with io.js by default (no runtime flag required)?
+## Hvilke ES6-funktioner leveres med io.js som standard (ingen runtime-flag påkrævet)?
 
 
 *   Block scoping
@@ -25,7 +25,7 @@ With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features ar
 
     *   `function`-in-blocks
 
-    >As of v8 3.31.74.1, block-scoped declarations are [intentionally implemented with a non-compliant limitation to strict mode code](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Developers should be aware that this will change as v8 continues towards ES6 specification compliance.
+    >Fra v8 3.31.74.1, er block-scoped-deklarationer [bevidst implementeret med en ikke-opfyldt begrænsning i forhold til strict-tilstandskode](https://groups.google.com/forum/#!topic/v8-users/3UXNCkAU8Es). Udviklere bør være opmærksomme på, at dette vil ændre sig, mens v8 bevæger sig nærmere opfyldelse af ES6-specifikationen.
 
 *   Collections
 
@@ -35,34 +35,36 @@ With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features ar
 
     *   [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
 
-    *   [WeakSet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet)*   [Generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*)
+    *   [WeakSet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet)
+
+    *   [Generatorer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*)
 
 *   [Binary and Octal literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_literals)
 
 *   [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
-*   [New String methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object)
+*   [Nye string-metoder](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla#Additions_to_the_String_object)
 
-*   [Symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
+*   [Symboler](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
 
-*   [Template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings)
+*   [Skabelon-strenge](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings)
 
-You can view a more detailed list, including a comparison with other engines, on the [compat-table](https://kangax.github.io/compat-table/es6/) project page.
+Du kan se en mere detaljeret liste, inklusiv en sammenligning med andre motorer, på [compat-table](https://kangax.github.io/compat-table/es6/)-projektsiden.
 
-## Which ES6 features are behind the --es_staging flag?
+## Hvis ES6-funktioner er gemt bag --es_staging-flaget?
 
-*   [Classes](https://github.com/lukehoban/es6features#classes) (strict mode only)
+*   [Klasser](https://github.com/lukehoban/es6features#classes) (kun strict mode)
 *   [Object literal extensions](https://github.com/lukehoban/es6features#enhanced-object-literals)
 
-*   [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) (user-definable results for `Object.prototype.toString`)
+*   [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) (brugerdefinerbare resultater for `Object.prototype.toString`)
 
-## I have my infrastructure set up to leverage the --harmony flag. Should I remove it?
+## Jeg har sat min infrastruktur op til at benytte sige af --harmony-flaget. Skal jeg fjerne det?
 
-The current behaviour of the `--harmony` flag on io.js is to enable **staged** features only. After all, it is now a synonym of `--es_staging`. As mentioned above, these are completed features that have not been considered stable yet. If you want to play safe, especially on production environments, consider removing this runtime flag until it ships by default on V8 and, consequently, on io.js. If you keep this enabled, you should be prepared for further io.js upgrades to break your code if V8 changes their semantics to more closely follow the standard.
+Den nuværende opførsel af `--harmony`-flaget i io.js har til formål kun at slå **staged**-funktioner til. Det er nu et synonym for `--es_staging`. Som nævnt ovenfor, så er det færdiggjorte funktioner, der ikke bliver betragtet som stabile endnu. Hvis du være på den sikre side, specielt i produktionsmiljøer, overvej at fjerne dette runtime-flag indtil det leveres som standard med V8 og derved også io.js. Hvis du vil beholde dette slået til, skal du være forberedt på at senere io.js-opgraderinger kan ødelægge din kode, hvis V8 ændrer deres semantik til at følge standarden tættere.
 
-## How do I find which version of V8 ships with a particular version of io.js?
+## Hvordan finder jeg ud af hvilken version af V8, der leveres med en bestemt version af io.js?
 
-io.js provides a simple way to list all dependencies and respective versions that ship with a specific binary through the `process` global object. In case of the V8 engine, type the following in your terminal to retrieve its version:
+io.js giver en simpel måde at liste alle dependencies og respektive versioner, der leveres med en specifik binary gennem det globale <code>process</code>-objekt. I forbindelse med V8-motoren, tast da det følgende ind i din terminal for at finde dens version:
 
 ```sh
 iojs -p process.versions.v8

--- a/content/da/faq.md
+++ b/content/da/faq.md
@@ -1,34 +1,32 @@
 # FAQ
 
-## What is io.js?
+## Hvad er io.js?
 
-[io.js](https://github.com/iojs/io.js) is a JavaScript platform built on [Chrome's V8 runtime](http://code.google.com/p/v8/). This project began as a fork of [Joyent's Node.js™](https://nodejs.org/) and is compatible with the [npm](https://www.npmjs.org/) ecosystem.
+[io.js](https://github.com/iojs/io.js) er en JavaScript-platform bygget på [Chromes V8-runtime](http://code.google.com/p/v8/). Dette projekt startede som en fork af <a href="https://nodejs.org/">Joyents Node.js™</a> og er kompatibelt med <a href="https://www.npmjs.org/">npm</a>-økosystemet.
 
-Why? io.js aims to provide faster and predictable release cycles. It currently merges in the latest language, API and performance improvements to V8 while also updating libuv and other base libraries.
+Hvorfor? io.js stiler efter at give hurtigere og mere forudsigelige udgivelsescyklusser. Det inkluderer på nuværende tidspunkt de seneste sprog-, API- og ydeevne-forbedringer til V8, mens også libuv og andre grundbiblioteker er opdateret.
 
-This project aims to continue development of io.js under an "[open governance model](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme)" as opposed to corporate stewardship.
+Dette projekt stiler efter at fortsætte udviklingen af io.js under en "[åben forvaltningsmodel](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme)" modsat virksomhedsforvaltning.
 
 ## Version 1.0.x?
 
-io.js has moved to [Semver](http://semver.org/) and the changes between Node.js™ 0.10 and io.js 1.0.0 were significant enough
-to warrant a major version increment.
+io.js er skiftet til [Semver](http://semver.org/) og ændringer mellem Node.js™ 0.10 og io.js 1.0.0 er betydelige nok til at kræve en stigning til næste større version.
 
-Our [CHANGELOG](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md) for v1.x provides a [summary of changes from Node.js v0.10.35 to io.js v1.0.x](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#summary-of-changes-from-nodejs-v01035-to-iojs-v100).
+Vores [CHANGELOG](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md) for v1.x giver en [oversigt over ændringerne fra Node.js v0.10.35 til io.js v1.0.x](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#summary-of-changes-from-nodejs-v01035-to-iojs-v100).
 
-## How can I contribute?
+## Hvordan kan jeg bidrage?
 
-Everyone can help. io.js adheres to a [code of conduct](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct), and contributions, releases, and contributorship are under an [open governance](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme) model.
+Alle kan hjælpe. io.js holder sig til et [adfærdskodeks](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct), og bidrag og udgivelser er underlagt en [åben forvaltningsmodel](https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme).
 
-To get started, there are open [ discussions on GitHub](https://github.com/iojs/io.js/issues), and we'd love to hear your feedback.
-Becoming involved in discussions is a good way to get a feel of where you can help out further. If there is
-something there you feel you can tackle, please [make a pull request](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-contributions).
+For at komme igang, er der åbne [ diskussioner på GitHub](https://github.com/iojs/io.js/issues) og vi vil meget gerne høre dine tilbagemeldinger.
+At blive en del af diskussioner er en god måde at få føling for, hvordan du kan hjælpe yderligere til. Hvis der er noget der, du føler, du kan håndtere, så [lav venligst en pull request](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-contributions).
 
-In addition, using [Nodebug.me](http://nodebug.me/) is a good way to help Triage the issues in the backlog.
+Udover det, er det at bruge [Nodebug.me](http://nodebug.me/) en god måde at hjælpe med at vurdere vigtigheden af eksisterende issues.
 
-## Where do discussions take place?
+## Hvor finder diskussioner sted?
 
-There is an #io.js channel on Freenode IRC. We keep logs of the channel [here](http://logs.libuv.org/io.js/latest).
+Der er en #io.js-kanal på Freenode IRC. Vi holder logs fra kanalen [her](http://logs.libuv.org/io.js/latest).
 
-## What is open source governance?
+## Hvad er open source-forvaltning?
 
-Open source governance advocates the application of the philosophies of the open source and open content movements in order to enable any interested party to add to the creation of the end product, as with a wiki document. Legislation is democratically opened to the general citizenry, employing their collective wisdom to benefit the decision-making process and improve democracy. [[source]](https://en.wikipedia.org/wiki/Open-source_governance)
+Open source-forvaltning taler for at bruge filosifierne fra open source- og open content-bevægelser for at give enhver interesseret part mulighed for at tilføje til skabelsen af slutproduktet, så vel som et wiki-dokument. Lovgivning er demokratisk åbnet op for generelle borgere, der bruger deres kollektive viden til at fordel for beslutningsprocessen og for at forbedre demokratiet. [[kilde]](https://en.wikipedia.org/wiki/Open-source_governance)

--- a/content/da/index.md
+++ b/content/da/index.md
@@ -1,22 +1,22 @@
 # JavaScript I/O
 
-Bringing [ES6](es6.html) to the Node Community!
+Bringer [ES6](es6.html) til Node-community'et!
 
-[io.js](https://github.com/iojs/io.js) is an [npm](https://www.npmjs.org/) compatible platform originally based on [node.js](https://nodejs.org/)&#8482;.
+[io.js](https://github.com/iojs/io.js) er en [npm](https://www.npmjs.org/)-kompatibel platform oprindeligt baseret på [node.js](https://nodejs.org/)&#8482;.
 
 [![io.js](../images/1.0.0.png)](https://iojs.org/dist/v1.1.0/)
 
 [Version 1.1.0](https://iojs.org/dist/v1.1.0/)
 
-Download for
+Download til
 [Linux](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.xz),
 [Win32](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi), [Win64](https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi),
-or
+eller
 [Mac](https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg).
 
 
 [Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
 
-[Nightly releases](https://iojs.org/download/nightly/) are available for testing.
+[Nightly releases](https://iojs.org/download/nightly/) er tilgængelige til testing.
 
-[Frequently Asked Questions](/faq.html)
+[Ofte stillede spørgsmål](/faq.html)

--- a/content/da/template.json
+++ b/content/da/template.json
@@ -3,10 +3,10 @@
   "logo-text":"io.js",
   "faq-link":"FAQ",
   "es6-link":"ES6",
-  "api-link":"API Docs",
-  "issues-link":"GitHub Issues",
-  "org-link":"GitHub Org",
-  "irc-link":"IRC Chat",
+  "api-link":"API-dokumentation",
+  "issues-link":"GitHub-issues",
+  "org-link":"GitHub-organisation",
+  "irc-link":"IRC-chat",
   "irc-logs-link":"Logs",
-  "gov-link":"Governance"
+  "gov-link":"Forvaltning"
 }


### PR DESCRIPTION
This adds a Danish translation of the website in the appropriate folder according to [TRANSLATION.md](https://github.com/iojs/website/blob/master/TRANSLATION.md).

Glossary is added here: https://github.com/iojs/iojs-da/wiki/Glossary

/cc @tjconcept, @Renetnielsen
