### PR TITLE
Define a consistent subject for localization PRs

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -16,5 +16,6 @@ would like to contribute to the translation of iojs.org, please refer to the fol
     * `faq.md` (this contains markdown for the faq page)
     * `es6.md` (this contains markdown for the ES6 explanation page)
     * Any additional md files that are to be added can be done here, and will be dynamically generated into html using the template.
+* Prefix your PR with the localization group's name (e.g. `iojs-no`). If you are only translating one of the above files, please mention them in your PR's subject as well.
 * Do not make language specific changes to layout or styling in a translation PR. If they are needed, make a separate styling/layout pr and chat with one of the website WG about the change. We want to make sure, for example, a Chinese layout change doesn't cascade failure to the German page.
 * To be merged, translation PR's require a Website WG +1 and a +1 from another native speaker in your language. Make sure whoever you have review the PR adds a +1 in the comments of it so we know it is translated properly.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -16,6 +16,13 @@ would like to contribute to the translation of iojs.org, please refer to the fol
     * `faq.md` (this contains markdown for the faq page)
     * `es6.md` (this contains markdown for the ES6 explanation page)
     * Any additional md files that are to be added can be done here, and will be dynamically generated into html using the template.
-* Prefix your PR with the localization group's name (e.g. `iojs-no`). If you are only translating one of the above files, please mention them in your PR's subject as well.
+* Prefix your PR with the localization group's name (e.g. `iojs-no`). If you are only translating one of the above files, please mention them in your PR's subject as well, e.g.:
+```
+    iojs-de: Add files - index.md, faq.md
+    iojs-pt: Add files - 15 files
+
+    iojs-fr: Update files - es6.md
+    iojs-ja: Update files - all files
+```
 * Do not make language specific changes to layout or styling in a translation PR. If they are needed, make a separate styling/layout pr and chat with one of the website WG about the change. We want to make sure, for example, a Chinese layout change doesn't cascade failure to the German page.
 * To be merged, translation PR's require a Website WG +1 and a +1 from another native speaker in your language. Make sure whoever you have review the PR adds a +1 in the comments of it so we know it is translated properly.


### PR DESCRIPTION
Looking at the first batch of translations, there are already a bunch of different ways to describe PRs ("My translations", "zh_TW", "chinese", "pt-BR"), which make it difficult to quickly scan l10n PRs for review/approval. Adding the group and file name makes it easier to set up custom issue filters, which will come in handy when the project gets even more translations.