### PR TITLE
Added relative markdown links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 
 ## Project Structure
 
-- [./content](https://github.com/iojs/website/tree/master/content) contains the source articles, organized by language-team groupings.
+- [./content](./content) contains the source articles, organized by language-team groupings.
   Articles are written in
   [Github-flavoured Markdown](https://help.github.com/articles/github-flavored-markdown/).
-- [./gulp](https://github.com/iojs/website/tree/master/gulp) organizes the [Gulp.js](http://gulpjs.com/)-driven build scripts used
+- [./gulp](./gulp) organizes the [Gulp.js](http://gulpjs.com/)-driven build scripts used
   by the project.
-- [./public](https://github.com/iojs/website/tree/master/public) **currently** contains the full library of website content generated
+- [./public](./public) **currently** contains the full library of website content generated
   by the build scripts. Changes should not be made directly here. Soon, we'll
   be switching over to leveraging [iojs/build](https://github.com/iojs/build)
   to help automate this.
-- [./source](https://github.com/iojs/website/tree/master/source) houses the reusable styling and structural elements used by the
+- [./source](./source) houses the reusable styling and structural elements used by the
   project.
-- [./wg-meetings](https://github.com/iojs/website/tree/master/wg-meetings) is an archive of the meeting minutes from this project's
-  Working Group (see [./GOVERNANCE.md](https://github.com/iojs/website/blob/master/GOVERNANCE.md)).
-
+- [./wg-meetings](./wg-meetings) is an archive of the meeting minutes from this project's
+  Working Group (see [./GOVERNANCE.md](./GOVERNANCE.md)).
+  
 ## Running Locally
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 ## Project Structure
 
-- [./content]() contains the source articles, organized by language-team groupings.
+- [./content](https://github.com/iojs/website/tree/master/content) contains the source articles, organized by language-team groupings.
   Articles are written in
   [Github-flavoured Markdown](https://help.github.com/articles/github-flavored-markdown/).
-- [./gulp]() organizes the [Gulp.js](http://gulpjs.com/)-driven build scripts used
+- [./gulp](https://github.com/iojs/website/tree/master/gulp) organizes the [Gulp.js](http://gulpjs.com/)-driven build scripts used
   by the project.
-- [./public]() **currently** contains the full library of website content generated
+- [./public](https://github.com/iojs/website/tree/master/public) **currently** contains the full library of website content generated
   by the build scripts. Changes should not be made directly here. Soon, we'll
   be switching over to leveraging [iojs/build](https://github.com/iojs/build)
   to help automate this.
-- [./source] houses the reusable styling and structural elements used by the
+- [./source](https://github.com/iojs/website/tree/master/source) houses the reusable styling and structural elements used by the
   project.
-- [./wg-meetings] is an archive of the meeting minutes from this project's
-  Working Group (see [./GOVERNANCE.md]()).
+- [./wg-meetings](https://github.com/iojs/website/tree/master/wg-meetings) is an archive of the meeting minutes from this project's
+  Working Group (see [./GOVERNANCE.md](https://github.com/iojs/website/blob/master/GOVERNANCE.md)).
 
 ## Running Locally
 


### PR DESCRIPTION
After a ton of messing around with git, I finally got relative links down without a million unhelpful commits. Should work.