### PR TITLE
Fix and activate 'minifyCss' task - #177

### DIFF
--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -2,7 +2,10 @@ var gulp = require('gulp');
 var runSequence = require('run-sequence');
 
 gulp.task('default', function(cb){
-  runSequence('clean',
-    ['stylus', 'templates', 'watch', 'server'],
-    cb);
+  runSequence(
+    'clean',
+    ['stylus', 'templates'],
+    'minifyCss',
+    ['watch', 'server'],
+  cb);
 });

--- a/gulp/tasks/minifyCss.js
+++ b/gulp/tasks/minifyCss.js
@@ -4,7 +4,6 @@ var postcss   = require('gulp-postcss');
 var autoprefixer = require('autoprefixer-core');
 var csswring  = require('csswring');
 var size      = require('gulp-filesize');
-var rename = require('gulp-rename');
 
 gulp.task('minifyCss', function() {
   return gulp.src(config.cssSrc)
@@ -12,9 +11,6 @@ gulp.task('minifyCss', function() {
       autoprefixer(),
       csswring
     ]))
-    .pipe(rename(function(path){
-      path.extname = '.min.css';
-    }))
     .pipe(gulp.dest(config.dest))
     .pipe(size());
 })

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   ],
   "dependencies": {
-    "autoprefixer-core": "^5.0.0",
+    "autoprefixer-core": "^5.1.5",
     "browserify": "^8.1.1",
     "csswring": "^3.0.0",
     "del": "^1.1.1",
@@ -54,7 +54,6 @@
     "gulp-less": "^2.0.1",
     "gulp-markdown": "^1.0.0",
     "gulp-postcss": "^4.0.2",
-    "gulp-rename": "^1.2.0",
     "gulp-stylus": "^2.0.0",
     "html-template": "^1.2.1",
     "lodash": "^2.4.1",


### PR DESCRIPTION
This
- activates and fixes the minifyCss task
- changes to gulp sequence so the minifyCss runs after 'stylus'
- removes the `rename` step, as the HTML doesn't seem to link to `.min.css` yet
- fixes #177
