### PR TITLE
Fix YouTube link for Jan WG Meeting

### DIFF
--- a/wg-meetings/2015-01-19.md
+++ b/wg-meetings/2015-01-19.md
@@ -1,7 +1,7 @@
 ## Meeting Details
 - Monday January 19, 2015 at 19:00 UTC
 - Original GitHub Issue (planning thread): https://github.com/iojs/website/issues/59
-- YouTube recording: https://www.youtube.com/watch?v=RgZAw-etur8
+- YouTube recording: https://www.youtube.com/watch?v=_U9ftC-Yy98
 - In attendance (_in order of self-introduction_):
   * Mikeal Rogers [@mikeal](https://github.com/mikeal), _meeting chair_
   * Jeremiah Senkpiel [@Fishrock123](https://github.com/Fishrock123)


### PR DESCRIPTION
The removed link went to the current livestream page. The new link goes
to the recording of the previous livestream.