### PR TITLE
add scripts for local gulp on package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@
 ### Dependencies
 ```
 git clone https://github.com/iojs/website.git
-npm install -g gulp
 npm install
 ```
 
 ### Local Development
 ```
-gulp
+npm run build
 ```
 Runs a local HTTP server on port 4657 with live-reload, which will update
 your browser immediately with content or style changes. Generated assets

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
       "github": "zeke"
     }
   ],
+  "scripts": {
+    "build": "gulp"
+  },
   "dependencies": {
     "autoprefixer-core": "^5.1.5",
     "browserify": "^8.1.1",


### PR DESCRIPTION
Hi!

We should use local gulp without global one.
It might be already installed another version of gulp.
