### PR TITLE
Remove the need to install `gulp` globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@
 ## Running Locally
 
 ### Dependencies
+
 ```
 git clone https://github.com/iojs/website.git
-npm install -g gulp
 npm install
 ```
 
 ### Local Development
+
 ```
-gulp
+npm run serve
 ```
+
 Runs a local HTTP server on port 4657 with live-reload, which will update
 your browser immediately with content or style changes. Generated assets
 are provided to the [./public]() directory for publishing.

--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
     "vinyl-source-stream": "^1.0.0"
+  },
+  "scripts": {
+    "build": "gulp build",
+    "serve": "gulp"
   }
 }


### PR DESCRIPTION
Instead of requiring the user to install `gulp` globally, use `npm`'s ["scripts"]( https://docs.npmjs.com/misc/scripts) field.