### PR TITLE
Release v1.4.3

### DIFF
--- a/content/es/es6.md
+++ b/content/es/es6.md
@@ -2,7 +2,7 @@
 
 io.js está construido sobre versiones modernas de [V8](https://code.google.com/p/v8/). Manteniéndolo actualizado con las últimas versiones de este motor nos aseguramos que las nuevas funcionalidades de la [especificación ECMA-262 de JavaScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm) estén disponibles para los desarrolladores de io.js de manera oportuna, así como también las mejoras de rendimiento y estabilidad.
 
-La versión 1.1.0 de io.js utiliza V8 {{project.current_v8}}, que incluye las mejoras de ES6 superando claramente la versión 3.26.33 que será incluida con joyent/node@0.12.x.
+La versión {{project.current_version}} de io.js utiliza V8 {{project.current_v8}}, que incluye las mejoras de ES6 superando claramente la versión 3.26.33 que será incluida con joyent/node@0.12.x.
 
 ## No más --harmony flag
 

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -4,15 +4,15 @@
 
 [io.js](https://github.com/iojs/io.js) es una plataforma compatible con [npm](https://www.npmjs.org/) y basada originalmente en [node.js](https://nodejs.org/)&#8482;.
 
-[![io.js](../images/1.0.0.png)](https://iojs.org/dist/v1.4.1/)
+[![io.js](../images/1.0.0.png)](https://iojs.org/dist/v{{project.current_version}}/)
 
-[Versión 1.4.1](https://iojs.org/dist/v1.4.1/)
+[Versión {{project.current_version}}](https://iojs.org/dist/v{{project.current_version}}/)
 
 Descargar para:
-[Linux](https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-x64.tar.xz),
-[Win32](https://iojs.org/dist/v1.4.1/iojs-v1.4.1-x86.msi), [Win64](https://iojs.org/dist/v1.4.1/iojs-v1.4.1-x64.msi),
+[Linux](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-linux-x64.tar.xz),
+[Win32](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-x86.msi), [Win64](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-x64.msi),
 ó
-[Mac](https://iojs.org/dist/v1.4.1/iojs-v1.4.1.pkg).
+[Mac](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}.pkg).
 
 
 [Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)

--- a/public/cn/es6.html
+++ b/public/cn/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>io.js 运行 ES6</h1>
 <p>io.js 是基于 <a href="https://code.google.com/p/v8/">V8</a> 引擎的较新版本构建的。通过持续跟进最新版的 V8 引擎，我们可以保证及时地为开发者带来最新的 <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 规范</a> 中的语言特性，同时也能得到性能和稳定性的提升。</p>
-<p>io.js 1.4.2 集成了 V8 4.1.0.21 版本，其中包含的 ES6 特性远超 joyent/node@0.12.x 集成的 3.26.33 版本所包含的。</p>
+<p>io.js 1.4.3 集成了 V8 4.1.0.21 版本，其中包含的 ES6 特性远超 joyent/node@0.12.x 集成的 3.26.33 版本所包含的。</p>
 <h2>干掉 --harmony</h2>
 <p>在 joyent/node@0.12.x (V8 3.26) 版本中，<code>--harmony</code> 运行时参数会一并开启所有 <strong>已完成</strong>，<strong>待完成</strong> 和 <strong>修订中</strong> 的 ES6 的一大堆特性 (除了 <code>typeof</code> 的非标准/不确定的特性需要通过 <code>--harmony-typeof</code> 开启之外)。这就意味着一些真正鸡肋甚至废弃的特性，譬如 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> 都会像 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a> 那样开放给开发者，它们很偏门，甚至缺少相关资料。因此，最好的做法是，要么通过加特定参数(例如 <code>--harmony-generators</code>) 开启稳定的特性，要么直接开启全部但严格地使用特定部分特性。</p>
 <p>使用 io.js@1.x (V8 4.1+)，妈妈再也不担心我了。所有的特性在逻辑上被分为 <strong>已完成</strong>，<strong>待完成</strong> 和 <strong>修订中</strong> 三部分：</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 83b91f97b2f161c4b80e9cba3e9cf8d83cbcccbb
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: eb2b33d6d6bd1e1a91d2c6037af5fe610dbf3b8c
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/cn/index.html
+++ b/public/cn/index.html
@@ -35,12 +35,12 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>将 <a href="es6.html">ES6</a> 带入 Node 社区！</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> 是一个衍生自 <a href="https://nodejs.org/">node.js</a>™ ，并兼容 <a href="https://www.npmjs.org/">npm</a> 的开发平台。</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">1.4.2 版本</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">1.4.3 版本</a></p>
 <p>下载
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>, 或 <a href="https://iojs.org/dist/v1.4.2/">其他</a> 版本。</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>, 或 <a href="https://iojs.org/dist/v1.4.3/">其他</a> 版本。</p>
 <p><a href="https://github.com/iojs/iojs-cn/blob/master/CHANGELOG.md">更新日志</a></p>
 <p><a href="https://iojs.org/download/nightly/">每日构建版本</a> 可用于测试。</p>
 <p><a href="faq.html">常见问题</a></p>
@@ -63,11 +63,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 83ea4dc67194d75e00e2d5ff4a488cb758a4df82
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 3cea338b6080d69f961ac01a562fbf2b68c86210
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/cs/es6.html
+++ b/public/cs/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 6948ad511e9fd56b306edffbbb6c6d07f651e31f
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 06df43c27dbdb481d58f78ce82cf765eb7943bcd
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/cs/index.html
+++ b/public/cs/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 5df174346264b3bb213e214484ee15e21564a997
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: d69f4e232d02e411f01768064971a1a2eadbf949
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/da/es6.html
+++ b/public/da/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 1c86f776229a964c85207bd88c1eab74a918b0da
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: b6e28ffb11196e3a751f2a8f15c1cbb9836c3b82
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/da/index.html
+++ b/public/da/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 176a1764c63c0d747ed8578eddb6805dbc11ae74
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 14bc36f0b236e6feca3c3049512e6769b5ec5a28
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/de/es6.html
+++ b/public/de/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 354820e84f3c74ebf320914bb9d14f739e394b30
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 0763a32cc8b4bce7c56c7ada10a695af09b20834
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/de/index.html
+++ b/public/de/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p><a href="es6.html">ES6</a> für die Node-Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> ist eine <a href="https://www.npmjs.org/">npm</a>-kompatible Plattform, die ursprünglich auf <a href="https://nodejs.org/">node.js</a>™ basiert.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Herunterladen für
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> oder
-<a href="https://iojs.org/dist/v1.4.2/">andere</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> oder
+<a href="https://iojs.org/dist/v1.4.3/">andere</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> stehen zum Testen zur Verfügung.</p>
 <p><a href="/faq.html">Häufig gestellte Fragen</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 4d720bc7873a72cc9fac7279d815629c39b7136f
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 26721998ce718b3adf095503436d2e09f344d9f2
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/el/es6.html
+++ b/public/el/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>H ES6 στην io.js</h1>
 <p>Η io.js έχει δομηθεί πάνω στις νεότερες εκδόσεις της <a href="https://code.google.com/p/v8/">V8</a>. Με συνεχείς ενημερώσεις σύμφωνα με τις τελευταίες εκδόσεις της V8 εξασφαλίζεται ότι νέες δυνατότητες και χαρακτηριστικά από την <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> προσφέρονται στους io.js developers εγκαίρως, καθώς και η συνεχής βελτιώση της απόδοσης και της σταθερότητας της.</p>
-<p>Η έκδοση 1.4.2 της io.js έρχεται μαζί με την έκδοση 4.1.0.21 της V8, η οποία περιλαμβάνει χαρακτηριστικά από την ES6, πολύ περισσότερα από την έκδοση 3.26.33 που προσφέρετε από την joyent/node@0.12.x.</p>
+<p>Η έκδοση 1.4.3 της io.js έρχεται μαζί με την έκδοση 4.1.0.21 της V8, η οποία περιλαμβάνει χαρακτηριστικά από την ES6, πολύ περισσότερα από την έκδοση 3.26.33 που προσφέρετε από την joyent/node@0.12.x.</p>
 <h2>Όχι πια --harmony flag</h2>
 <p>Στην joyent/node@0.12.x (V8 3.26), με <code>--harmony</code> runtime flag ενεργοποιούνται όλες μαζί οι δυνατότητες της ES6 είτε είναι <strong>ολοκληρωμένες (completed)</strong>, είτε <strong>σε φάση ελέγχου (staged)</strong> είτε <strong>υπό ανάπτυξη (in progress)</strong> (με εξαίρεση τα nonstandard/non-harmonious semantics για το <code>typeof</code> τα οποία βρίσκονται υπό το flag <code>--harmony-typeof</code>). Αυτό σημαίνει πως κάποια χαρακτηριστικά τα οποία περιέχουν σφάλματα ή δεν λειτουργούν καθόλου, όπως π.χ. <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> ήταν διαθέσιμα στους developers μαζί με χαρακτηριστικά τα οποία είχαν λίγα ή καθόλου γνωστά προβλήματα όπως π.χ. οι <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>. Ως εκ τούτου, ήταν καλή πρακτική είτε να ενεργοποιείς μόνο συγκεκριμένα χαρακτηριστικά χρησιμοποιώντας συγκεκριμένα runtime harmony flags (π.χ. <code>--harmony-generators</code>), είτε να ενεργοποιείς όλα τα χαρακτηριστικά και να χρησιμοποιείς μόνο ένα υποσύνολο από αυτά.</p>
 <p>Με την io.js@1.x (V8 4.1+), όλη αυτή η πολυπλοκότητα εξαλείφεται. Όλα τα χαρακτηριστικά της έκδοσης harmony είναι λογικά διαχωρισμένα σε τρεις ομάδες <strong>έτοιμα (shipping)</strong>, <strong>σε φάση ελέγχου(staged)</strong> και <strong>υπό ανάπτυξη(in progress)</strong>:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 64e9b2e44357c7597022102d3844d49635c7231e
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: fa3d1a0620004bb1d384fc15b6da752ec731db6e
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/el/index.html
+++ b/public/el/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Φέρνουμε την <a href="es6.html">ES6</a> στην κοινότητα του Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> είναι μια πλατφόρμα συμβατή με το <a href="https://www.npmjs.org/">npm</a>,  βασισμένη στο <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Κατεβάστε για
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> ή
-<a href="https://iojs.org/dist/v1.4.2/">others</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> ή
+<a href="https://iojs.org/dist/v1.4.3/">others</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Ιστορικό</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly εκδόσεις</a> είναι διαθέσιμες για testing.</p>
 <p><a href="/faq.html">Συχνές ερωτήσεις</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: a84d5da3a097a53f2931689f01d01aaa501c6e37
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: f0daeb9e9b445120536e9fbbcc5d1d895a811739
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/en/es6.html
+++ b/public/en/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.28.73 that ship with Node.js™ 0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.28.73 that ship with Node.js™ 0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On Node.js™@0.12.x (V8 3.28+), the <code>--harmony</code> runtime flag enables all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of <code>proxies</code> which are hidden under <code>--harmony-proxies</code>). This means that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a> are just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which have very little or even no known-issues. As such, most developers tend to enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -141,11 +141,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 5f4a2a571f64820bd01f16f79ff90c70cb87f3d8
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: c2dc47847b90d5c331b0179899666aa1402de5b3
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> or
-<a href="https://iojs.org/dist/v1.4.2/">others</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> or
+<a href="https://iojs.org/dist/v1.4.3/">others</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 6948c84f1c22f560517accb38006cc5195a1626d
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: a82ba246c92e18afe3b4f8df29e4d4950859328d
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/es/es6.html
+++ b/public/es/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 en io.js</h1>
 <p>io.js está construido sobre versiones modernas de <a href="https://code.google.com/p/v8/">V8</a>. Manteniéndolo actualizado con las últimas versiones de este motor nos aseguramos que las nuevas funcionalidades de la <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">especificación ECMA-262 de JavaScript</a> estén disponibles para los desarrolladores de io.js de manera oportuna, así como también las mejoras de rendimiento y estabilidad.</p>
-<p>La versión 1.1.0 de io.js utiliza V8 4.1.0.21, que incluye las mejoras de ES6 superando claramente la versión 3.26.33 que será incluida con joyent/node@0.12.x.</p>
+<p>La versión 1.4.3 de io.js utiliza V8 4.1.0.21, que incluye las mejoras de ES6 superando claramente la versión 3.26.33 que será incluida con joyent/node@0.12.x.</p>
 <h2>No más --harmony flag</h2>
 <p>En joyent/node@0.12.x (V8 3.26), la flag <code>--harmony</code> habilita todas las mejoras <strong>completed</strong>, <strong>staged</strong> e <strong>in progress</strong> de ES6, en una sola (con la excepción de los semánticos non-standard/non-harmonious para <code>typeof</code> el cuál está oculto bajo  <code>--harmony-typeof</code>).  Esto significaba que algunas mejoras experimentales o incluso dañadas, como <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a>, estaban tan fácilmente disponibles para los desarrolladores como <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, lo cual traía muy pocos o casi nulos problemas conocidos. Así, era mejor práctica habilitar sólo algunas mejoras usando flags harmony específicas (ej. <code>--harmony-generators</code>), o simplemente habilitarlas todas y después restringirlas una por una.</p>
 <p>Con  io.js@1.x (V8 4.1+), toda la complejidad queda eliminada. Todas las mejoras harmony están ahora equitativamente separadas en tres grupos: <strong>shipping</strong>, <strong>staged</strong> e <strong>in progress</strong>.</p>
@@ -133,11 +133,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-02-26 23:13:46 UTC
+Build Time: 2015-03-02 23:29:38 UTC
 
-Commit Sha: 6c600bad98d85681edbc2efedc9cd3aa6f02a980
-Commit Msg: update v8 version to 4.1.0.21 in all languages
-Hashsum: df7254a50a574f00e848c9bf3addd4ecfbcbf88a
+Commit Sha: 01082cf726004d26e40a765fd37c1fcfd0f6c78d
+Commit Msg: Merge branch 'master' into release-v1.4.3
+Hashsum: 0cbd547852d9b53007fcc456af3a225679ff9dad
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/es/index.html
+++ b/public/es/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>¡Llevando <a href="es6.html">ES6</a> a la Comunidad de Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> es una plataforma compatible con <a href="https://www.npmjs.org/">npm</a> y basada originalmente en <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.1.0/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.1.0/">Versión 1.1.0</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Versión 1.4.3</a></p>
 <p>Descargar para:
-<a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 ó
-<a href="https://iojs.org/dist/v1.1.0/iojs-v1.1.0.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> están disponibles para pruebas.</p>
 <p><a href="/faq.html">Preguntas frecuentes</a></p>
@@ -64,11 +64,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-02-26 12:44:12 UTC
+Build Time: 2015-03-02 23:29:38 UTC
 
-Commit Sha: 68970fd56e9b43ccbb6bfd2d7720ef484936f92f
-Commit Msg: Initial public template changes resulting from template modifications
-Hashsum: 89aad33663f3c2509f345f6282f60017b4f0e674
+Commit Sha: 01082cf726004d26e40a765fd37c1fcfd0f6c78d
+Commit Msg: Merge branch 'master' into release-v1.4.3
+Hashsum: 2df9d46616a3c846dad6a29383e3f1300098655e
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/fi/es6.html
+++ b/public/fi/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 ja io.js</h1>
 <p>io.js nojaa tuoreisiin <a href="https://code.google.com/p/v8/">V8</a>:n versioihin. Pysymällä ajan tasalla viimeisimpien versioiden kanssa varmistetaan sekä uusimpien <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> ominaisuuksien, että suorituskykyyn ja vakauteen liittyvien parannusten nopea saapuminen kehittäjien ulottuville.</p>
-<p>io.js:n versio 1.4.2 sisältää V8 version 4.1.0.21, mikä ES6:n osalta ylittää tuntuvasti ominaisuuksiltaan version 3.28.72 mikä sisältyy Node.js™ 0.12.x-versioihin.</p>
+<p>io.js:n versio 1.4.3 sisältää V8 version 4.1.0.21, mikä ES6:n osalta ylittää tuntuvasti ominaisuuksiltaan version 3.28.72 mikä sisältyy Node.js™ 0.12.x-versioihin.</p>
 <h2>Ei enää --harmony lippua</h2>
 <p>Node.js™@0.12.x (V8 3.28+) ajonaikainen <code>--harmony</code>-lippu aktivoi kaikki <strong>valmiit</strong>, <strong>koekäyttövaiheen</strong> ja <strong>kehitysvaiheen</strong> ES6-ominaisuudet (poikkeuksena <code>proxies</code>, joille on oma <code>--harmony-proxies</code>-lippunsa). Toisin sanoen jotkin bugiset tai jopa rikkinäiset ominaisuudet kuten <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a> on yhtä lailla käytettävissä kuin <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, millä on vähän tai ei yhtään tunnettuja ongelmia. Usein kehittäjät ottavat käyttöön vain tiettyjä ominaisuuksia käyttämällä täsmällisiä ajonaikaisia ominaisuuslippuja (esim. <code>--harmony-generators</code>), tai yksinkertaisesti ottavat kaiken käyttöön ja pitäytyvät käytössään rajatussa osassa.</p>
 <p>io.js@1.8 (V8 4.1+) myötä nuo hankaluudet poistuvat. Kaikki harmonyn ominaisuudet on nyt loogisesti jaoteltu kolmeen ryhmään, eli <strong>valmiisiin</strong>, <strong>koekäyttövaiheen</strong> ja <strong>kehitysvaiheen</strong> ominaisuuksiin:</p>
@@ -141,11 +141,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: fd4ddfb1db9c37be36d7ffabf4c4692465016e12
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 5bb506f491a65a389799bbe3fc00c13849187a2c
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/fi/index.html
+++ b/public/fi/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Tuomme <a href="es6.html">ES6</a>:n Node-yhteisölle!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> on <a href="https://www.npmjs.org/">npm</a>-yhteensopiva alusta joka perustuu <a href="https://nodejs.org/">node.js</a>™:n.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Versio 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Versio 1.4.3</a></p>
 <p>Lataa io.js:
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linuxille</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Windowsille (32-bittinen)</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Windowsille (64-bittinen)</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Macille</a> tai
-<a href="https://iojs.org/dist/v1.4.2/">muu</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linuxille</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Windowsille (32-bittinen)</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Windowsille (64-bittinen)</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Macille</a> tai
+<a href="https://iojs.org/dist/v1.4.3/">muu</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Jokailtaiset (<em>nightly</em>) julkaisut</a> koekäyttötarkoituksiin.</p>
 <p><a href="/fi/faq.html">Usein kysytyt kysymykset</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 2c9a37e0af12882e7c7049959de1efafa472b531
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 92df41ad500d8e6c899e48f47d3f6ee27d33371e
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/fr/es6.html
+++ b/public/fr/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 et io.js</h1>
 <p>io.js est construit sur des versions modernes de <a href="https://code.google.com/p/v8/">V8</a>. En restant à jour avec les dernières livraisons du moteur, nous nous assurons que les dernières fonctionnalités de la <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">spécification JavaScript ECMA-262</a> sont mises à disposition des développeurs io.js en continu, ainsi que des améliorations de performance et de stabilité.</p>
-<p>La version 1.4.2 d'io.js est livrée avec V8 4.1.0.21 qui inclue des fonctionnalités ES6 qui vont bien au delà de la version 3.28.73 qui sera fournie avec joyent/node@0.12.x.</p>
+<p>La version 1.4.3 d'io.js est livrée avec V8 4.1.0.21 qui inclue des fonctionnalités ES6 qui vont bien au delà de la version 3.28.73 qui sera fournie avec joyent/node@0.12.x.</p>
 <h2>Disparition de l'option --harmony</h2>
 <p>Avec joyent/node@0.12.x (V8 3.28+), l'option <code>--harmony</code> activait toutes les fonctionnalités d'ES6 en même temps, qu'elles soient <strong>shipping</strong> (livrées), <strong>staged</strong> (en phase d'acceptation) ou <strong>in progress</strong> (en développement) (à l'exception de la sémantique non-standard/non-harmony de <code>typeof</code> qui était cachée derrière l'option <code>--harmony-typeof</code>). Ceci signifiait que certaines fonctionnalités défectueuses ou inopérantes telles que les <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxy</a> étaient mises à disposition tout comme les <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">générateurs</a>, qui en revanche n'avaient que peu de défauts connus. De fait, il est de bonne pratique d'activer uniquement certaines fonctionnalités via l'utilisation d'options d'éxécution de fonctionnalités harmony (comme `--harmony-generators par exemple), ou simplement de toutes les activer mais de n'en utiliser qu'une partie.</p>
 <p>Avec io.js@1.x (V8 4.1+), cette complexité disparait. Toutes les fonctionnalités d'harmony sont à présent séparées en trois groupes distincts: <strong>livrées</strong>, <strong>en phase d'acceptation</strong> ou <strong>en développement</strong>.</p>
@@ -141,11 +141,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 36c18a8d9c48797edf77fb752af5be3847fc2f85
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: d60f44f9f1ef4a972c7892a3613bb4f2870aa7ca
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/fr/index.html
+++ b/public/fr/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p><a href="es6.html">ES6</a> pour la communauté Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> est une plateforme compatible avec <a href="https://www.npmjs.org/">npm</a> et basée sur <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Télécharger pour
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 ou
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p>Les <a href="https://iojs.org/download/nightly/">Nightly releases</a> sont disponibles pour des tests.</p>
 <p><a href="/faq.html">Foire aux questions</a></p>
@@ -64,11 +64,11 @@ ou
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: e8090d14d4addc8539307b732f4bf517c1eb05a7
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: d09c743a28f4b739dee93163384e1e10f4fe498f
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/he/es6.html
+++ b/public/he/es6.html
@@ -36,7 +36,7 @@
 # ES6 ב io.js 
 <p>נבנה לצד הגרסאות העדכניות של מנוע ה <a href="https://code.google.com/p/v8/">V8</a>.
 שמירה על עדכניות ומודרניות מבטיחים לנו כפלטפורמה לספק את המלוא התכונות החדשות מ<a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> מבעוד מועד. כמו כן, שיפורי ביצועים יציבות וכיוצא בזה.</p>
-<p>גרסת 1.4.2 מובאת עם גרסת 4.1.0.21 של הV8 שכוללת תכונותֿ/פיצ׳רים מES6 (ראה למטה), בשונה מגרסת 3.26.33 של הV8 שמובאת עם גרסה 0.12 של joyent/node</p>
+<p>גרסת 1.4.3 מובאת עם גרסת 4.1.0.21 של הV8 שכוללת תכונותֿ/פיצ׳רים מES6 (ראה למטה), בשונה מגרסת 3.26.33 של הV8 שמובאת עם גרסה 0.12 של joyent/node</p>
 <h1>אין יותר את הדגל --harmony</h1>
 <p>בגרסת 0.12 של Joyent/node דגל הזמן ריצה(--harmony) מדליק/מביא לשימוש את כל התכונות/פיצ׳רים ה״יציבים״, ב&quot;staging&quot;, וב-״inprogress״/בפיתוח של ES6.(משמע, כי ייתכן ״באגים״, ״׳פיצ׳רים לא שלמים״ וכיוצא בזה. למשל: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Function</a> אשר זמינים בחופשיות לשימוש כמו: Generators (אשר כמעט יציבים לחלוטין).
 לכן, רוב המשתמשים מעדיפים להדליק דגלים ספציפים למשל: <code>--harmony-generators</code>.
@@ -142,11 +142,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 4194b582e96328d4dc90cae24a373c7eb8873138
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 8a213830048d6eeea6ca57ac413cdc60b9939590
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/he/index.html
+++ b/public/he/index.html
@@ -40,13 +40,13 @@
 <a href="https://nodejs.org/">node.js</a>™
 תואמת
 <a href="https://www.npmjs.org/">npm</a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">גרסא 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">גרסא 1.4.3</a></p>
 <p>הורדות
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 או
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">שינויים אחרונים</a></p>
 <p><a href="https://iojs.org/download/nightly">בנייה ליילית</a>
 מוצעת לצורכי בדיקה</p>
@@ -70,11 +70,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: a080e61140471d73b4d1676eb8cbd1a1b63b5357
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 11b034f333a697a60ee23c99cc6fe57ae88a69fe
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/hi/es6.html
+++ b/public/hi/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 5de2e6ff40389c93fa3e8d0c3df9f9b1bdbc149d
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: c750f6b5b6032b16eee06b601b502a2092bc59ae
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/hi/index.html
+++ b/public/hi/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 3136cbc7c5b6bbec7eec696fb76e73efd74da066
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: e7dae2f3ee969bdefb65a2168ee0d46723ef874c
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/hu/es6.html
+++ b/public/hu/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: f3b72eb7a23fcbfc5bbed8d9c01b6615549614d2
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 4d730d4388a0906429c36b2ff37dd33880cf79c3
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/hu/index.html
+++ b/public/hu/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 04eb47f77593bf6c6ccd393daae838679d70e698
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 7d398f2c0584bc83c0e2b65544702400d81d8d26
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/id/es6.html
+++ b/public/id/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 pada io.js</h1>
 <p>io.js dikembangkan dengan versi modern dari <a href="https://code.google.com/p/v8/">V8</a>. Dengan menjaga tetap teranyar dengan rilis terbaru dari <em>engine</em> ini kami memastikan fitur terbaru dari <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 spesifikasi</a>  tersedia untuk pengembang io.js dengan tepat waktu, serta perbaikan yang berkelanjutan pada kinerja dan stabilitas.</p>
-<p>Versi 1.4.2 dari io.js dikeluarkan dengan V8 4.1.0.21, yang meliputi ES6 fitur jauh melampaui versi 3.26.33 yang akan dikirim dengan joyent/node@0.12.x.</p>
+<p>Versi 1.4.3 dari io.js dikeluarkan dengan V8 4.1.0.21, yang meliputi ES6 fitur jauh melampaui versi 3.26.33 yang akan dikirim dengan joyent/node@0.12.x.</p>
 <h2>Tidak ada lagi --harmony flag</h2>
 <p>Di joyent/node@0.12.x (V8 3.26), <code>--harmony</code> <em>flag</em> runtime memungkinkan semua <strong>diselesaikan</strong>, <strong>staged</strong> dan <strong>in progress</strong> fitur ES6 bersama-sama, dalam jumlah besar (dengan pengecualian tidak standar/semantik non-harmonis untuk <code>typeof</code> yang tersembunyi di bawah<code>--harmony-typeof</code>). Ini berarti bahwa beberapa fitur yang sangat <em>buggy</em> atau bahkan rusak seperti <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxy</a> hanya sebagai tersedia untuk pengembang sebagai <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, yang memiliki sangat sedikit atau bahkan tidak ada yang diketahui-masalah. Dengan demikian, itu praktek terbaik baik memungkinkan hanya fitur tertentu dengan menggunakan flag fitur runtime harmoni tertentu (misalnya <code>--harmony-generators</code>), atau dengan mengaktifkan semua dari mereka dan kemudian menggunakan subset terbatas.</p>
 <p>Dengan io.js@1.x (V8 4.1+), semua kerumitan itu hilang. Semua fitur harmoni sekarang dibagi dengan logis menjadi tiga kelompok untuk <strong>shipping</strong>, <strong>staged</strong> dan <strong>in progress</strong> fitur:</p>
@@ -135,11 +135,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 474c027c53c2a022eea8e715c37bb46bf343ae26
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 2844e7a21f4bcf9b5ca5d9d11510296fb4154e21
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/id/index.html
+++ b/public/id/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Membawa <a href="es6.html">ES6</a> ke Komunitas Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> adalah <a href="https://www.npmjs.org/">npm</a> platform yang kompatibel dengan [node.js] (https: //nodejs.org/)™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Versi 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Versi 1.4.3</a></p>
 <p>Unduh untuk
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Log Perubahan</a></p>
 <p><a href="https://iojs.org/download/nightly/">Rilis setiap malam</a> tersedia untuk pengujian.</p>
 <p><a href="/faq.html">Pertanyaan yang sering ditanyakan</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 52402de3ad563d26b2d0e127f5a127d0dcf0f284
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 8115213974e5b205e382bd7077b389ffd3e755ec
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/it/index.html
+++ b/public/it/index.html
@@ -35,15 +35,15 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p><a href="es6.html">ES6</a> per la Comunità Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> è una piattaforma compatibile con <a href="https://www.npmjs.org/">npm</a> basata originariamente su <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download per
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>,
 o
-<a href="https://iojs.org/dist/v1.4.2/">altro</a>,</p>
+<a href="https://iojs.org/dist/v1.4.3/">altro</a>,</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p>Sono disponibili le <a href="https://iojs.org/download/nightly/">Nightly releases</a> per essere testate.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -66,11 +66,11 @@ o
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 302fc4ddc671fbcf558517802b8e98300c66e95e
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 844c270092d3d79befa3ff8e3b5ca07fb3b31351
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ja/es6.html
+++ b/public/ja/es6.html
@@ -38,9 +38,9 @@ io.js is built against modern versions of [V8](https://code.google.com/p/v8/). B
 -->
 <p>io.jsは新しいバージョンの<a href="https://code.google.com/p/v8/">V8エンジン</a>を対象にビルドされています。V8エンジンを最新版に保つことで、io.js開発者は<a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMA-262 specification</a>で定義されたJavaScriptの新機能をすぐに利用することができます。</p>
 <!-- 
-Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.28.73 that ship with Node.js™ 0.12.x.
+Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.28.73 that ship with Node.js™ 0.12.x.
 -->
-<p>io.js 1.4.2はV8 4.1.0.21を利用しています。これはNode.js™ 0.12.xが利用しているV8 3.28.73よりもES6サポートが進んだバージョンです。</p>
+<p>io.js 1.4.3はV8 4.1.0.21を利用しています。これはNode.js™ 0.12.xが利用しているV8 3.28.73よりもES6サポートが進んだバージョンです。</p>
 <!-- 
 ## No more --harmony flag 
 -->
@@ -217,11 +217,11 @@ io.js provides a simple way to list all dependencies and respective versions tha
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 7c5fb3c0b0797b6608889825d660ce621a7fef4a
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 75bd1ea901f1c20b2dca33ec0178a67d9e85f496
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -41,14 +41,14 @@ Bringing [ES6](es6.html) to the Node Community!
 [io.js](https://github.com/iojs/io.js) is an [npm](https://www.npmjs.com/) compatible platform originally based on [node.js](https://nodejs.org/)&#8482;. 
 -->
 <p><a href="https://github.com/iojs/io.js">io.js</a>は、<a href="https://nodejs.org/">node.js</a>™をベースに作られた<a href="https://www.npmjs.com/">npm</a>互換プラットフォームです。</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> or
-<a href="https://iojs.org/dist/v1.4.2/">others</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> or
+<a href="https://iojs.org/dist/v1.4.3/">others</a>.</p>
 <!-- 
 [Changelog](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)
 -->
@@ -80,11 +80,11 @@ Bringing [ES6](es6.html) to the Node Community!
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 2852437c6a7f4de6dd33bacba84661d07c109273
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: f4336ab836ad64e10118e212e9afc95a20ca8684
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ka/es6.html
+++ b/public/ka/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 3859ee383b2adc6eded91e3e0ee50b0ffcf26a8a
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 78fccaa640f24e82a85046fcc94b7de1708fddc7
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ka/index.html
+++ b/public/ka/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 693e80cedf4bf7300939c2d23ce3ed42c561b7f4
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 904f527b2e57ebd9fad0911cd74b409dc0d7088a
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ko/es6.html
+++ b/public/ko/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>io.js의 ES6</h1>
 <p>io.js는 <a href="https://code.google.com/p/v8/">V8</a>의 새로운 버전으로 빌드한다. V8 엔진의 최신 버전을 사용함으로써 <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 사양</a>의 신기능을 io.js 개발자가 즉시 이용할 수 있을 뿐만 아니라, 지속적인 성능과 안정성 개선 또한 보장하게 된다.</p>
-<p>io.js 1.4.2 버전은 V8 4.1.0.21와 함께 제공되는데, 이는 Node.js™ 0.12.x의 3.28.73 버전보다 더 많은 ES6 기능이 구현되어 있다.</p>
+<p>io.js 1.4.3 버전은 V8 4.1.0.21와 함께 제공되는데, 이는 Node.js™ 0.12.x의 3.28.73 버전보다 더 많은 ES6 기능이 구현되어 있다.</p>
 <h2>--harmony 플래그는 이제 그만</h2>
 <p>Node.js™@0.12.x (V8 3.28+)에서 <code>--harmony</code> 플래그를 사용하면 ES6 기능에서 <strong>완료됨</strong>, <strong>준비됨</strong>, <strong>진행 중</strong> 상태인 (<code>--harmony-proxies</code> 밑에 숨어 있는 <code>proxies</code>를 제외하고) 모든 기능을 사용할 수 있게 한다. 이 말은 거의 문제없는 <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function*">제네레이터</a>도, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a> 같은 정말 버그가 많거나 망가져 있는 기능도 사용 가능하게 된다는 이야기이다. 그래서 개발자 대부분은 특정 하모니 기능 플래그(예를 들어 <code>--harmony-generators</code>)를 사용해 특정 기능만 사용하거나, 모두 사용 가능하게 한 다음에 일부분만 사용하는 경향이 있다.</p>
 <p>io.js@1.x (V8 4.1+)는 이렇게 복잡하지 않도록 모든 하모니 기능을 논리적인 3가지 그룹 <strong>배포 중</strong>, <strong>준비됨</strong>, <strong>개발 중</strong>으로 나뉜다.</p>
@@ -141,11 +141,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 07e75518edf737761093c06ee4ac0769257efce6
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: b38e3e830319ea40e07d81bd055962c2fbfa26a7
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ko/index.html
+++ b/public/ko/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p><a href="es6.html">ES6</a>를 노드 커뮤니티에!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a>는 <a href="https://nodejs.org/">node.js</a>™를 기반으로 만든 <a href="https://www.npmjs.org/">npm</a> 호환 플랫폼이다.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">버전 1.4.2</a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>,
-<a href="https://iojs.org/dist/v1.4.2/">기타</a> 다운로드.</p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">버전 1.4.3</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>,
+<a href="https://iojs.org/dist/v1.4.3/">기타</a> 다운로드.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">변경이력</a></p>
 <p>테스트 용으로 <a href="https://iojs.org/download/nightly/">Nightly 릴리스</a>를 사용할 수 있다.</p>
 <p><a href="/faq.html">FAQ</a></p>
@@ -64,11 +64,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 98f5e85e8c40e8b5af8b4313cc7b08908d0410ad
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 0639912b2a0c61e0c7790e94ab067c17dc93c886
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/mk/es6.html
+++ b/public/mk/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 3e1b3af68eaaefe63e71d288aca4d06da5519ad7
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: aad9cda8525e6e7b4387e86e605e9d8a2c87536e
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/mk/index.html
+++ b/public/mk/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: c6ad61cac370d70441b242f39af9d6569940228e
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 535510956164e325d0f6e6e233f1dd84b023ed86
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/nl/es6.html
+++ b/public/nl/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 5f09d4f6428d220d5b89b6ff3d8dc0d91c030ca2
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 81b5168018927086a081d8e8caf5416c9dab91eb
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/nl/index.html
+++ b/public/nl/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: c96996e958b68b6c3337e6399ba7a6015409c23f
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 46d1e090aa8f7eefc6713c5a86a10a50b94f4fe0
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/no/es6.html
+++ b/public/no/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: a6a04f4dff46d856f392a29cc2fe6cf94bf293e7
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: a70ff7c4548e5b2da7328cab83c79caf49ce602f
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/no/index.html
+++ b/public/no/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: ab709ac17e82baf6a75c5643c3266a2ce3c3051c
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 4745464b29fb54a31cf201466f91b836fcad74b7
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/pl/es6.html
+++ b/public/pl/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 0e0c003a559d946bfaa91557936405b5863fd82e
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 6275923b78763256075c8bcd17e404b5c76ce019
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/pl/index.html
+++ b/public/pl/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: c4ace28e434b39208f7132f9873e5d0fb0297678
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 869845723b13ce4be28d8b25533616bfb1b08413
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/pt_BR/es6.html
+++ b/public/pt_BR/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 no io.js</h1>
 <p>O io.js é construído usando versões modernas do <a href="https://code.google.com/p/v8/">V8</a>. Mantendo-nos atualizados com as últimas versões desta engine, garantimos que novas funcionalidades da <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">especificação JavaScript ECMA-262</a> são trazidas para desenvolvedores io.js rapidamente, além de manter performance continuada e melhorias de estabilidade.</p>
-<p>A versão 1.4.2 do io.js vem com o V8 4.1.0.21, que inclui funcionalidades do ES6 bem além da versão 3.26.33 que vem com o joyent/node@0.12.x.</p>
+<p>A versão 1.4.3 do io.js vem com o V8 4.1.0.21, que inclui funcionalidades do ES6 bem além da versão 3.26.33 que vem com o joyent/node@0.12.x.</p>
 <h2>Não mais flag --harmony</h2>
 <p>No joyent/node@0.12.x (V8 3.26), a flag de runtime <code>--harmony</code> habilitava todas funcionalidades ES6 <strong>completas</strong>, <strong>em teste</strong> e <strong>em progresso</strong> juntas, de uma vez só (com a exceção de semânticas não padrão/não harmoniosas para <code>typeof</code> que estavam escondidas sob <code>--harmony-typeof</code>). Isto significava que algumas funcionalidades realmente bugadas ou mesmo quebradas como os <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> estavam prontamente disponíveis para desenvolvedores como os <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, que tinham poucos ou mesmo nenhuma issue conhecida. Portanto, era uma boa prática ou habilitar apenas certas funcionalidades usando flags de runtime harmony para funcionalidades específicas (por ex. <code>--harmony-generators</code>), ou simplesmente habilitar tudo e depois usar apenas um subconjunto restrito.</p>
 <p>Com o io.js@1.x (V8 4.1+), toda esta complexidade vai embora. Todas as funcionalidades harmony agora estão logicamente divididas em três grupos para funcionalidades <strong>entregues</strong>, <strong>sob testes</strong> e <strong>em progresso</strong>:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 08977a60019a51b478f549337891287085a2333b
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 168db9c28781b3eb3c8ccd0e112b181b75707744
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/pt_BR/index.html
+++ b/public/pt_BR/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Levando o <a href="es6.html">ES6</a> para a Comunidade Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> é uma plataforma compatível com o <a href="https://www.npmjs.org/">npm</a>, originalmente baseada no <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Versão 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Versão 1.4.3</a></p>
 <p>Download para
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 ou
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Releases nightly</a> estão disponíveis para testes.</p>
 <p><a href="faq.html">Perguntas Frequentes (FAQ)</a></p>
@@ -64,11 +64,11 @@ ou
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: e95a959fa90ddfd4ab8f3889817ebae5f7baae9c
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: ca80b4d8428e24bf5c1c01228c3cd27e6c243680
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/pt_PT/es6.html
+++ b/public/pt_PT/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 no io.js</h1>
 <p>O io.js é compilado com versões modernas do <a href="https://code.google.com/p/v8/">V8</a>. Mantendo-nos atualizados com a última versão deste motor, garantimos que as novas funcionalidades da <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">especificação JavaScript ECMA-262</a> são disponibilizadas rapidamente aos programadores io.js, bem como as melhorias de performance e estabilidade.</p>
-<p>A versão 1.4.2 do io.js vem com o V8 4.1.0.21 que inclui funcionalidades ES6 muito além da versão 3.26.33 presente no joyent/node@0.12.x.</p>
+<p>A versão 1.4.3 do io.js vem com o V8 4.1.0.21 que inclui funcionalidades ES6 muito além da versão 3.26.33 presente no joyent/node@0.12.x.</p>
 <h2>Chega de --harmony flag</h2>
 <p>No joyent/node@0.12.x (V8 3.26), a flag de runtime <code>--harmony</code> ativava todas as funcionalidades <strong>entregues</strong>, <strong>em teste</strong>, e <strong>em desenvolvimento</strong> do ES6, em simultâneo e de uma só vez (com a exceção da não-padrão/não-harmoniosa semântica para <code>typeof</code> que estava escondida sob <code>--harmony-typeof</code>). Isto significava que algumas funcionalidades com bugs ou até mesmo funcionalidades partidas como os <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a>, estavam imediatamente disponíveis aos programadores, tal como os <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, que tinham poucos ou nenhum problema conhecido. Como tal, era boa prática apenas habilitar algumas funcionalidades utilizando flags específicas de runtime harmony (p.e <code>--harmony-generators</code>), ou simplesmente habilitar todas as funcionalidades e usar apenas um subconjunto específico.</p>
 <p>Com o io.js@1.x (V8 4.1+), toda essa complexidade deixa de existir. Todas as funcionalidades harmony estão agora logicamente separadas em três grupos: <strong>entregues</strong>, <strong>em testes</strong> e <strong>em desenvolvimento</strong>:</p>
@@ -142,11 +142,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 6294bbd12f9a55e367d3356edb443954618cd653
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: b1a227919faf4f25ec6eb3b6b973fbe7f787f18e
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/pt_PT/index.html
+++ b/public/pt_PT/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>A trazer <a href="es6.html">ES6</a> à comunidade Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> é uma plataforma compatível com o <a href="https://www.npmjs.org/">npm</a> originalmente baseada em <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download para
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 ou
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Versões Nightly</a> estão disponíveis para teste.</p>
 <p><a href="faq.html">Perguntas Frequentes (FAQ)</a></p>
@@ -64,11 +64,11 @@ ou
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: d9791392234dde7d5687e54bfd0675578ba26ed3
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: ef7217c263100c62ee3e566829e9abeca6cc8cea
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ru/es6.html
+++ b/public/ru/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 в io.js</h1>
 <p>В основе io.js стоит современная версия <a href="https://code.google.com/p/v8/">V8</a>. Придерживаясь самых последних версий этого движка, мы гарантируем, что новые возможности <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">спецификации JavaScript ECMA-262</a> станут доступны разработчикам io.js своевременно, а вместе с ними и улучшения, связанные с производительностью и стабильностью.</p>
-<p>Версия io.js 1.4.2 основана на версии V8 4.1.0.21, которая включает в себя гораздо больше возможностей ES6 в отличие от версии 3.28.73, на которой основан joyent/node@0.12.x</p>
+<p>Версия io.js 1.4.3 основана на версии V8 4.1.0.21, которая включает в себя гораздо больше возможностей ES6 в отличие от версии 3.28.73, на которой основан joyent/node@0.12.x</p>
 <h2>Теперь без флага --harmony</h2>
 <p>В joyent/node@0.12.x (V8 3.28) флаг <code>--harmony</code> включает все <strong>completed</strong>, <strong>staged</strong> и <strong>in progress</strong> возможности ES6 одновременно, (исключая нестандартную семантику для <code>typeof</code>, которая скрыта за флагом <code>--harmony-typeof</code>). Это означает, что некоторые содержащие множество ошибок возможности, такие как <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">прокси</a>, одинаково доступны для разработчиков как и, например, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">генераторы</a>, которые имеют очень мало или вообще не имеют известных проблем. Поэтому, хорошей практикой было бы либо включать только конкретные возможности, используя определенные флаги harmony (например <code>--harmony-generators</code>), или включить все, но использовать ограниченное их подмножество.</p>
 <p>В io.js@1.x (V8 4.1+) исчезает любая сложность. Все возможности спецификации логически разделены на три группы — <strong>shipping</strong>, <strong>staged</strong> и <strong>in progress</strong>:</p>
@@ -135,11 +135,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: b8fed42e9cef6b7ea560bb751ce514f88bd25e39
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 9f2a592116e1fa4f7005b1b5ad2fbbd3f5640eef
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/ru/index.html
+++ b/public/ru/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p><a href="es6.html">ES6</a> для Node-сообщества!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> — <a href="https://www.npmjs.org/">npm</a>-совместимая платформа, разработанная на основе <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Версия 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Версия 1.4.3</a></p>
 <p>Скачать для
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> и
-<a href="https://iojs.org/dist/v1.4.2/">других</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> и
+<a href="https://iojs.org/dist/v1.4.3/">других</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Изменения</a></p>
 <p><a href="https://iojs.org/download/nightly/">Ночные сборки</a> доступны для тестирования.</p>
 <p><a href="/faq.html">Часто Задаваемые Вопросы</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 0abcf1dc76dc1a8bf8d2f417a1a186eb114a5141
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: ac8f9d14d5234450e8a299175d9c7a3354432cc8
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/sv/es6.html
+++ b/public/sv/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 on io.js</h1>
 <p>io.js is built against modern versions of <a href="https://code.google.com/p/v8/">V8</a>. By keeping up-to-date with the latest releases of this engine we ensure new features from the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> are brought to io.js developers in a timely manner, as well as continued performance and stability improvements.</p>
-<p>Version 1.4.2 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
+<p>Version 1.4.3 of io.js ships with V8 4.1.0.21, which includes ES6 features well beyond version 3.26.33 that will be shipped with joyent/node@0.12.x.</p>
 <h2>No more --harmony flag</h2>
 <p>On joyent/node@0.12.x (V8 3.26), the <code>--harmony</code> runtime flag enabled all <strong>completed</strong>, <strong>staged</strong> and <strong>in progress</strong> ES6 features together, in bulk (with the exception of nonstandard/non-harmonious semantics for <code>typeof</code> which were hidden under <code>--harmony-typeof</code>). This meant that some really buggy or even broken features like <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">proxies</a> were just as readily available for developers as <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">generators</a>, which had very little or even no known-issues. As such, it was best practice to either enable only certain features by using specific runtime harmony feature flags (e.g. <code>--harmony-generators</code>), or simply enable all of them and then use a restricted subset.</p>
 <p>With io.js@1.x (V8 4.1+), all that complexity goes away. All harmony features are now logically split into three groups for <strong>shipping</strong>, <strong>staged</strong> and <strong>in progress</strong> features:</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 99d99aaa33d618763be8bd0e7d8246e04b138c77
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 887de4d6c013a4bb4dff07bb8346327a4323c7a6
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/sv/index.html
+++ b/public/sv/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Bringing <a href="es6.html">ES6</a> to the Node Community!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> is an <a href="https://www.npmjs.org/">npm</a> compatible platform originally based on <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Version 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Version 1.4.3</a></p>
 <p>Download for
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
 or
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Changelog</a></p>
 <p><a href="https://iojs.org/download/nightly/">Nightly releases</a> are available for testing.</p>
 <p><a href="/faq.html">Frequently Asked Questions</a></p>
@@ -64,11 +64,11 @@ or
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: ee572b4b3eec28cb61b2914df48d2a805133919b
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: b354d3300b226828c164fdb9a5248f90489489e5
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/tr/index.html
+++ b/public/tr/index.html
@@ -35,13 +35,13 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p><a href="es6.html">ES6</a>'ı Node topluluğuna kazandırdık</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a>, <a href="https://nodejs.org/">node.js</a>'e dayalı  ve <a href="https://www.npmjs.org/">npm</a>'le uyumlu bir platformdur™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Sürüm 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Sürüm 1.4.3</a></p>
 <p>Yüklenebilir Dağıtımlar
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-ve <a href="https://iojs.org/dist/v1.4.2/">diğerleri</a>
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>, <a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+ve <a href="https://iojs.org/dist/v1.4.3/">diğerleri</a>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Değişiklikler</a></p>
 <p>Test amaçlı olarak <a href="https://iojs.org/download/nightly/">gecelik derlemeleri kullanabilirsiniz</a></p>
 <p><a href="/faq.html">Sık Sorulan Sorular</a></p>
@@ -64,11 +64,11 @@ ve <a href="https://iojs.org/dist/v1.4.2/">diğerleri</a>
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 4cfdb5c1ba374619554cb64ced1422a9e967e056
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: dec32a0a52d597ed1cac53bb88438c49822eb30f
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/uk/es6.html
+++ b/public/uk/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>ES6 в io.js</h1>
 <p>io.js побудований на основі сучасних версій <a href="https://code.google.com/p/v8/">V8</a>. Підтримуючи останні версії <a href="https://code.google.com/p/v8/">V8</a> в io.js, ми гарантуємо наявність нових можливостей <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a>, які привносяться до io.js розробників своєчасно, а також підвищують швидкість роботи та стабільність.</p>
-<p>Версія io.js 1.4.2 має версію V8 4.1.0.21, яка включає в себе ES6 можливості, котрих немає в V8 3.28.73, яка іде в поставці з Node™@0.12x.</p>
+<p>Версія io.js 1.4.3 має версію V8 4.1.0.21, яка включає в себе ES6 можливості, котрих немає в V8 3.28.73, яка іде в поставці з Node™@0.12x.</p>
 <h1>Більше ніяких --harmony параметрів</h1>
 <p>В Node.js™@0.12x (V8 3.28+), --harmony параметр вмикає всі <strong>shipping</strong>, <strong>staged</strong> та <strong>in progress</strong> ES6 можливості (окрім proxies, котрі вмикаються параметром --harmony-proxies). Це означає що код з помилками, чи навіть непрацюючі можливості, наприклад <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a> стають доступними в коді так само, як і <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">генератори</a>, котрі не мають відомих проблем взагалі. Багато розробників вмикають лише ті можливості, котрі їм потрібні, використовуючи параметри запуску (наприклад, <code>--harmony-generators</code>). Чи взагалі, вмикають всі можливості одним параметром.</p>
 <p>З io.js@1.x (V8 4.1+) складність використання ES6 можливостей зникає. Всі harmony можливості логічно розподілені на три групи <strong>shipping</strong>, <strong>staged</strong> та <strong>in progress</strong>:</p>
@@ -142,11 +142,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 4bdfd6fa950ec432d09fa06431d995e6385f06e1
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 2d5828868be3d44f9aa96ac588c6155361810f9c
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/uk/index.html
+++ b/public/uk/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>Впровадження <a href="es6.html">ES6</a> в спільноту Node!</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> це <a href="https://www.npmjs.org/">npm</a> сумісна платформа, що побудована на основі <a href="https://nodejs.org/">node.js</a>™.</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">Версія 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">Версія 1.4.3</a></p>
 <p>Завантажити для
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> чи
-<a href="https://iojs.org/dist/v1.4.2/">інших ОС</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> чи
+<a href="https://iojs.org/dist/v1.4.3/">інших ОС</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">Історія змін</a></p>
 <p><a href="https://iojs.org/download/nightly/">Нічні релізи</a> доступні для завантаження і тестування.</p>
 <p><a href="/faq.html">FAQ</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 84ea4f533baebf70d15f6f8a76b7425f8fa2dc2b
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: d09508a02f9c89a92a590051cef757534084325e
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/zh_TW/es6.html
+++ b/public/zh_TW/es6.html
@@ -34,7 +34,7 @@
 
   <div class="content clearfix"><h1>io.js 的 ES6</h1>
 <p>io.js 建構於目前版本的 <a href="https://code.google.com/p/v8/">V8</a> 之上，將會持續更新並引入最新的引擎版本，以確保最新的 <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">JavaScript ECMA-262 specification</a> 特性能以最短的時間內被 io.js 的開發人員所使用，並藉著不斷快速更新此持續改善效能及穩定度。</p>
-<p>目前釋出的 io.js v1.4.2 版本已採用 V8 4.1.0.21，其支援的 ES6 特性遠超過 joyent/node@0.12.x 所使用的 V8 3.26.23 。</p>
+<p>目前釋出的 io.js v1.4.3 版本已採用 V8 4.1.0.21，其支援的 ES6 特性遠超過 joyent/node@0.12.x 所使用的 V8 3.26.23 。</p>
 <h2>不再需要 --harmony 參數</h2>
 <p>在 joyent/node@0.12.x (V8 3.26) 上，參數 <code>--harmony</code> 將會一次啟用所有處於<strong>完成（completed）</strong>、**階段性（staged）<strong>及</strong>程序中（in progress）**狀態之下的 ES6 特性支援（除了 <code>proxies</code> ，此特性在使用參數 <code>--harmony-proxies</code> 時會被隱藏）。這意味著一些臭蟲或是很有問題的特性像是 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a> ，可能將會很容易的被開發人員所誤用在專案中，就如同沒有問題的特性 <code>generators</code> 一般。因此，大多數的開發人員通常會代入一些參數，只啟動特定的 harmony 特性支援（如：<code>--harmony-generators</code>），或是直接啟用所有的特性支援，然後在開發時限定只使用特定某些穩定的功能。</p>
 <p>不過在使用 io.js@1.x (V8 4.1+) 之後，前面所提到的所有麻煩將不再是問題。現在所有的 harmony 特性都將會被分類到不同的群組中，分別為 <strong>shipping</strong> 、 <strong>staged</strong> 和 <strong>in progress</strong>：</p>
@@ -136,11 +136,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: b1c1a5b5f53a6039a5ea9cd8c1a08f78dfc9a4cc
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: d7da151ddeb176a11bad0d2752b77d71e20da16c
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/public/zh_TW/index.html
+++ b/public/zh_TW/index.html
@@ -35,14 +35,14 @@
   <div class="content clearfix"><h1>JavaScript I/O</h1>
 <p>讓 <a href="es6.html">ES6</a> 走入 Node.js 社群！</p>
 <p><a href="https://github.com/iojs/io.js">io.js</a> 是一個與 <a href="https://www.npmjs.org/">npm</a> 相容並以 <a href="https://nodejs.org/">node.js</a>™ 為基礎的應用程式平台。</p>
-<p><a href="https://iojs.org/dist/v1.4.2/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
-<p><a href="https://iojs.org/dist/v1.4.2/">目前版本 1.4.2</a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/"><img src="../images/1.0.0.png" alt="io.js"></a></p>
+<p><a href="https://iojs.org/dist/v1.4.3/">目前版本 1.4.3</a></p>
 <p>下載各種平台版本
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.xz">Linux</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x86.msi">Win32</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2-x64.msi">Win64</a>,
-<a href="https://iojs.org/dist/v1.4.2/iojs-v1.4.2.pkg">Mac</a> or
-<a href="https://iojs.org/dist/v1.4.2/">others</a>.</p>
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.xz">Linux</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x86.msi">Win32</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3-x64.msi">Win64</a>,
+<a href="https://iojs.org/dist/v1.4.3/iojs-v1.4.3.pkg">Mac</a> or
+<a href="https://iojs.org/dist/v1.4.3/">others</a>.</p>
 <p><a href="https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md">更新日誌</a></p>
 <p>每天定時釋出的 <a href="https://iojs.org/download/nightly/">Nightly releases</a> 版本開放測試！</p>
 <p><a href="faq.html">常見問與答</a></p>
@@ -65,11 +65,11 @@
 <!--
 =========== BUILD INFORMATION ===========
 
-Build Time: 2015-03-01 00:47:46 UTC
+Build Time: 2015-03-01 00:59:13 UTC
 
-Commit Sha: e00b7f5270dc4ea17df8c6a6dccdd124244b2fff
-Commit Msg: Fixes to the order for when handlebars should execute on markdown
-Hashsum: 4140b95665eb9acac9d81baf66523079dca8faad
+Commit Sha: 94d6715bb4c3660b4177c84ad0c8234e8e5ac00d
+Commit Msg: Generated public/ with latest version (1.4.2)
+Hashsum: 58bd2f54429da9e2071177cbd270fac1a348d894
 
 =========== END BUILD INFORMATION ===========
 -->

--- a/source/project.json
+++ b/source/project.json
@@ -1,4 +1,4 @@
 {
-  "current_version": "1.4.2",
+  "current_version": "1.4.3",
   "current_v8": "4.1.0.21"
 }


### PR DESCRIPTION
Latest version is v1.4.2 but v1.4.3 is coming fast as per https://github.com/iojs/io.js/issues/995

Blocked as per https://github.com/iojs/io.js/issues/1017 -- do not merge for now.