### PR TITLE
Refactors/simplify the “Templates” task in a more gulp-like way

### DIFF
--- a/content/en/template.json
+++ b/content/en/template.json
@@ -1,5 +1,6 @@
 {
   "browser-title":"io.js - JavaScript I/O",
+  "contribute-message":"See something you like? Want to help? Visit https://github.com/iojs/website to contribute",
   "logo-text":"io.js",
   "faq-link":"FAQ",
   "es6-link":"ES6",

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -1,120 +1,157 @@
-var _ = require('lodash'); // to handle collections gracefully
-var config = require('../config').templates; // pull in the pathing config file
-var fs = require('fs'); // used to work with substack's module
-var glob = require('glob'); // to dynamically read in all content md files
-var gulp = require('gulp'); // because this is a gulp task. duh.
-var md = require('markdown-it')({ html: true }); // to convert markdown to html
-var source = require('vinyl-source-stream'); // used to convert substack's readStream to vinylStream
-var moment = require('moment-timezone');
-var exec = require('child_process').exec
-var utils = require('../util/template-utils.js');
+/*
+ * 1. because this is a gulp task. duh.
+ * 2. to convert markdown to html
+ * 3. handlebars is used to convert `{{ }}` placeholders
+ *    in markdown, html, to output
+ * 4. we get an un-buffered stream we need 100% loaded in order
+ *    to properly process
+ * 5. the map function helps us "inject" our custom processing steps in to the
+ *    incoming file buffer
+ * 6. renames our files for output
+ * 7. brings in our own shared `utils`
+ */
+var fs = require('fs');
 var path = require('path');
-var crypto = require("crypto");
-var gulpif = require('gulp-if');
-var gulpHandlebars = require('gulp-compile-handlebars');
-var Handlebars = require('handlebars');
-var buffer = require('vinyl-buffer');
-var rename = require('gulp-rename');
+var gulp = require('gulp'); /* 1 */
+var md = require('markdown-it')({ html: true }); /* 2 */
+var Handlebars = require('handlebars'); /* 3 */
+var buffer = require('vinyl-buffer'); /* 4 */
+var vinylMap = require('vinyl-map'); /* 5 */
+var rename = require('gulp-rename'); /* 6 */
+var utils = require('../util/template-utils.js'); /* 7 */
+
+
+/*
+  generateContentAndTemplates()
+  =============
+  This function wraps some lookups and caching around otherwise repeated actions
+  within the run of the task returned.
+
+  In general, the purpose is to:
+  - take incoming Markdown files** and inject in dictionary variables
+  - render the post-processed Markdown in to HTML
+  - fetch the appropriate template (HTML)
+  - Inject in dictionary variables and feed the HTML **content** (from markdown)
+    in to the template.
+  - Return the final combined HTML through to the vinyl stream.
+
+  ** later, we want to accept incoming HTML partials as well
+     (not all pages will be Markdown based)
+
+  Returns: a gulp-friendly pipe task (function)
+*/
+function generateContentAndTemplates() {
+  var base, projectJSON, i18nJSON, hbsTemplates;
+
+  /*
+   * cache variables and lookups used on subsequent runs of the pipe task:
+   *
+   * 1. `base` directory of project
+   * 2. `contentBase` is the root directory where the task is getting its content,
+   *     this is helpful later for processing out which i18n we're looking at
+   * 3. `projectJSON` is global, re-used across all languages
+   * 4. `i18nJSON` caches the template JSON for each language (avoids duplicated work)
+   * 5. `hbsTemplates` caches the handlebars FUNCTION for each template to save overhead
+   */
+  base = path.resolve(__dirname, '..', '..'); /* 1 */
+  contentBase = path.resolve(base, 'content'); /* 2 */
+  projectJSON = require('../../source/project.json'); /* 3 */
+  i18nJSON = {}; /* 4 */
+  hbsTemplates = {}; /* 5 */
+
+  // we returned a wrapped function to help us cache some work (above)
+  return function(contentBuffer, file) {
+    var fileName, contentRaw, lang, templateJSON, contentHandlebarsCompiled,
+        contentMarkdownCompiled, template, contentTemplateCompiled;
+
+    fileName = path.parse(file).name
+    contentRaw = contentBuffer.toString();
+
+    // determine the language based off of the current path
+    lang = path.relative(contentBase, path.dirname(file)).split(path.sep)[0];
+
+    if (i18nJSON[lang] == null) {
+      i18nJSON[lang] = utils.loadTemplateJSON(lang);
+    }
+
+    // load the current dictionary for the selected lang
+    templateJSON = {
+      i18n: i18nJSON[lang],
+      lang: lang,
+      build: {
+        markdownPage: fileName,
+        pageStylesheet: fileName
+      },
+      project: projectJSON
+    }
+
+    // initial Handlebars compile, Markdown content, before parsing
+    // (otherwise the `{{ }}` can be escaped)
+    contentHandlebarsCompiled = Handlebars.compile(contentRaw)(templateJSON);
+
+    // Turn `.md` in to `.html`
+    contentMarkdownCompiled = md.render(contentHandlebarsCompiled)
+
+    // this is hard-coded right now, but planned to be dynamic:
+    template = 'main.html';
+
+    // fetch the final template function we need (if not already cached)
+    if (hbsTemplates[template] == null) {
+      var templateBody =  fs.readFileSync(path.join(base, 'source', 'templates', template), {encoding: 'utf8'});
+      hbsTemplates[template] = Handlebars.compile(templateBody);
+    }
+
+    // Adds the inner-content already processed to the templateJSON
+    // as the dictionaries may be re-used between both levels:
+    templateJSON.content = contentMarkdownCompiled;
+
+    // Compile a version of the template with the content inside:
+    contentTemplateCompiled = hbsTemplates[template](templateJSON)
+
+    // Return as a Buffer for additional processing:
+    return new Buffer(contentTemplateCompiled);
+  }
+};
+
+/*
+ * processMarkdown will take markdown files (from content) and apply any
+ * template and variables needed. See `generateContentAndTemplates()` for
+ * the bulk of the work this task provides.
+ *
+ * Arguments:
+ * - `eventOrStream`: an event (from a `watch` trigger) or a vinyl stream
+ * - `filePath` a specific pattern (glob string).
+ *
+ * note: processMarkdown allows you to specify `event == null` with
+ * `filePath == "a glob string"` to explictly regenerate one or more files
+ * without having to pass in an existing event or stream
+ *
+ * Returns: a vinyl stream
+ */
+var processMarkdown = function(eventOrStream, filePath) {
+  // If we have an existing vinyl stream continue with it, otherwise create one
+  if (eventOrStream != null && eventOrStream.pipe) {
+    stream = eventOrStream;
+  } else {
+    // A check for incoming watch events, which will provide a `path` attribute:
+    if (eventOrStream != null && eventOrStream.path) {
+      filePath = path.relative(path.resolve(__dirname, '..', '..'), eventOrStream.path);
+    }
+    stream = gulp.src(filePath, {base: 'content/'});
+  }
+
+  return stream
+    .pipe(buffer())
+    .pipe(vinylMap(generateContentAndTemplates()))
+    .pipe(rename({extname: '.html'}))
+    .pipe(gulp.dest('public/'))
+}
 
 gulp.task('templates', function() {
-  var separator = '<SEPARATOR>';
-  var cmd = 'git log --no-color --pretty=format:\'[ "%H", "%s", "%cr", "%an" ],\' --abbrev-commit';
-  var projectJSON = require('../../source/project.json');
-  cmd = cmd.replace(/"/g, separator);
-  _command(cmd, function(str) {
-    str = str.substr(0, str.length - 1);
-    str = str.replace(/"/g, '\\"');
-    str = str.replace(/\\\./g, '\\\\.');
-    str = str.replace(new RegExp(separator, 'g'), '"');
-    var commits = JSON.parse('[' + str + ']');
-    var thisCommit = commits[0];
-    var commitSha = thisCommit[0];
-    var commitMsg = thisCommit[1];
-    var commitUser = thisCommit[3];
-    var buildTime = moment().tz('UTC').format('YYYY-MM-DD HH:mm:ss') + ' UTC'
-    var contentFiles = glob.sync(config.contentSrc); // read in all content files in the repo
-    var languages = _.uniq(_.map(contentFiles, function(str) { // extrapolate the languages from the content filepaths
-      return str.split('/')[2];
-    }));
-    _.forEach(languages, function(lang) { // loop through languages to make separate folder outputs
-      var templateJSON = utils.loadTemplateJSON(lang); // read in the template JSON file
-      var markdownFilesInThisLang = utils.loadMdFiles(contentFiles, lang); // load all the md files
-
-      _.forEach(markdownFilesInThisLang, function(file) { // iterate over the md files present in this language to apply the template to them
-        var markdownRaw = String(fs.readFileSync(file.srcPath)); // read in the md file, convert buffer to string
-        var markdownHandlebars = Handlebars.compile(markdownRaw)({
-          project: projectJSON
-        });
-        var html = md.render(markdownHandlebars); // convert md string to html string
-        var thisFileJSON = _.cloneDeep(templateJSON); // clone in the template JSON object
-        var pageTitle = thisFileJSON['browser-title'];
-        var filepath = __dirname.split('gulp/tasks')[0] + 'source/templates/main.html'; // get the main template file location. There can be multiple, this is just a proof of concept
-        var destinationDirectory = path.dirname('public/' + file.filepathArray.join('/'));
-        var changedFileCache = [];
-
-        var isChangedFile = function(vinylFile) {
-          if (vinylFile.isNull()) {
-            return;
-          }
-          if (changedFileCache[vinylFile.path] != null) {
-            return changedFileCache[vinylFile.path];
-          }
-          var currentFilePath = path.join(destinationDirectory, file.filename + '.html');
-          if (fs.existsSync(currentFilePath) === false) {
-            return true;
-          }
-          var currentContent = fs.readFileSync(currentFilePath, {encoding: 'utf8'});
-
-          var currentHash = currentContent.match(/Hashsum:\s(\b([a-f0-9]{40})\b)/);
-          if (currentHash && currentHash.length > 2) {
-            currentHash = currentHash[1]
-          } else {
-            currentHash = null
-          }
-
-          var contents = String(vinylFile.contents);
-
-          var newHash = crypto
-            .createHash("sha1")
-            .update(vinylFile.contents, "binary")
-            .digest("hex");
-
-          var isChanged = (currentHash !== newHash);
-
-          if (isChanged) {
-            contents = contents.replace(/Hashsum:(?:\s+\b([a-f0-9]{40})\b)?/, `Hashsum: ${newHash}`)
-            contents = contents.replace('Build Time:', `Build Time: ${buildTime}`)
-            contents = contents.replace('Commit Sha:', `Commit Sha: ${commitSha}`)
-            contents = contents.replace('Commit Msg:', `Commit Msg: ${commitMsg}`)
-            vinylFile.contents = new Buffer(contents);
-          }
-          changedFileCache[vinylFile.path] = isChanged;
-          return isChanged;
-        };
-
-        var templateContent = {
-          i18n: thisFileJSON,
-          content: html,
-          lang: lang,
-          build: {
-            markdownPage: file.filename,
-            pageStylesheet: file.filename
-          },
-          project: projectJSON
-        };
-
-        var fileStream = gulp.src(filepath) // pulling this code from substack's example on html-template
-          .pipe(rename(file.filename + '.html')) // converting the readStream to a vinyl stream so gulp can write it back to the disk
-          .pipe(buffer())
-          .pipe(gulpHandlebars(templateContent))
-          .pipe(gulpif(isChangedFile, gulp.dest(destinationDirectory))); // dump it in the appropriate language subfolder
-      });
-    });
-  });
+  var stream = gulp.src('content/**/*.md');
+  return processMarkdown(stream);
 });
 
-function _command(cmd, cb) {
-  exec(cmd, function(err, stdout, stderr) {
-    cb(stdout.split('\n').join(''))
-  })
+module.exports = {
+  processMarkdown: processMarkdown
 }

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,11 +1,27 @@
 var gulp = require('gulp');
 var config = require('../config');
 
+/* Default Watch task
+ * ==================
+ * Live project regeneration as one works within iojs/website.
+ * 1. watches for any CSS (stylus) changes, regenerating as needed
+ * 2. triggers re-rendering **all** markdown files, when:
+      a. any `source/templates` HTML file changes,
+ *    b. any localization `template.json` changes +++
+ * 3. triggered re-rendering of **individual** markdown files when they change.
+ *
+ * +++ we are aggressive with 2b. as a change to the `en/template.json` could
+ *     cause other localizations to have different output (english is the
+ *     default fallback for undefined dictionary variables)
+ */
+
+var processMarkdown = require('./templates').processMarkdown; /* for 3 */
+
 gulp.task('watch', function(callback) {
-  gulp.watch(config.stylus.src, ['stylus']);
+  gulp.watch(config.stylus.src, ['stylus']); /* 1 */
   gulp.watch([
-    config.templates.templateSrc,
-    config.templates.contentSrc,
-    config.templates.templateJSONsrc
+    config.templates.templateSrc,  /* 2a */
+    config.templates.templateJSONsrc  /* 2b */
   ], ['templates']);
+  gulp.watch([config.templates.contentSrc], processMarkdown); /* 3 */
 });

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
     "vinyl-buffer": "^1.0.0",
+    "vinyl-map": "^1.0.1",
     "vinyl-source-stream": "^1.0.0"
   }
 }

--- a/source/templates/main.html
+++ b/source/templates/main.html
@@ -44,18 +44,7 @@
     </nav>
   </footer>
 
-<!-- See something you like? Want to help? Visit https://github.com/iojs/website to contribute  -->
+<!-- {{i18n.contribute-message}}  -->
 </body>
 
 </html>
-<!--
-=========== BUILD INFORMATION ===========
-
-Build Time:
-
-Commit Sha:
-Commit Msg:
-Hashsum:
-
-=========== END BUILD INFORMATION ===========
--->


### PR DESCRIPTION
Open questions:
- [x] Discussion on whether or not we want to still continue to include build information as per #168 (it might be best to make this a production-environment flag for when we generate automatic builds.) If so, it can be added back prior to merging.
- [ ] What dependencies in the `package.json` are no longer needed

To do (non-blockers):
- [ ] Proof-of-concept metadata tracking around using alternative templates on certain articles
- [ ] Tracking a manifest of what articles are to be created (for i18n cross-linking.)
- [ ] Proof-of-concept page that is **not** markdown based. Example: the homepage shouldn't really be a markdown file, but I may make a new page (like downloads/ release history/ etc.) as a test.
- [ ] Live reload integration

Notes:
- Adds a lot of commenting, the refactor may be easier to review as the final file versus reading a diff.
- Snuck in a fix for #225
- This can be merged as-is. The output `public/**/*.html` is the same, except for the removal of the build information. (The non-blockers above can land later.)

Edit: I originally reported the refactor was (suspiciously) slower now than the original. But, in fact, because Gulp is reporting the original version of this task as completed near-instantly and not factoring in work which was is processing, this benchmark is incorrect.

On my modern MacBook Pro I'm getting about 1700ms **less** runtime with the refactor when manually benchmarking `gulp templates` with a `process.on('exit', /* ... */)` hook shared between the two branches:

``` javascript
console.time("gulp");

// Require all tasks in gulp/tasks, including subfolders
requireDir('./gulp/tasks', { recurse: true });

process.on('exit', function() { console.timeEnd("gulp"); });
```

To be fair, this refactor also does less work (no git log parsing, no checksum lookup/checks.)
