### PR TITLE
Adds i18n footer links (for all known active languages)

### DIFF
--- a/content/cn/template.json
+++ b/content/cn/template.json
@@ -1,6 +1,7 @@
 {
   "browser-title":"io.js - JavaScript I/O",
   "logo-text":"io.js",
+  "heading-languages":"其他语言",
   "faq-link":"常见问题",
   "es6-link":"ES6",
   "api-link":"API 文档",

--- a/content/en/template.json
+++ b/content/en/template.json
@@ -1,6 +1,7 @@
 {
   "browser-title":"io.js - JavaScript I/O",
   "contribute-message":"See something you like? Want to help? Visit https://github.com/iojs/website to contribute",
+  "heading-languages":"Languages",
   "logo-text":"io.js",
   "faq-link":"FAQ",
   "es6-link":"ES6",

--- a/content/fr/template.json
+++ b/content/fr/template.json
@@ -1,5 +1,7 @@
 {
   "browser-title":"io.js - JavaScript I/O",
+  "contribute-message":"Quelque chose vous plaît ? Envie de nous aider ? Allez sur https://github.com/iojs/website pour contribuer",
+  "heading-languages":"Langues",
   "logo-text":"io.js",
   "faq-link":"FAQ",
   "es6-link":"ES6",

--- a/content/ko/template.json
+++ b/content/ko/template.json
@@ -1,5 +1,6 @@
 {
   "browser-title":"io.js - JavaScript I/O",
+  "heading-languages":"언어",
   "logo-text":"io.js",
   "faq-link":"FAQ",
   "es6-link":"ES6",

--- a/content/pt_PT/template.json
+++ b/content/pt_PT/template.json
@@ -1,5 +1,7 @@
 {
   "browser-title":"io.js - JavaScript I/O",
+  "contribute-message":"Gosta do que vê? Quer ajudar? Visite https://github.com/iojs/website para contribuir",
+  "heading-languages":"Idiomas",
   "logo-text":"io.js",
   "faq-link":"FAQ",
   "es6-link":"ES6",

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -82,6 +82,15 @@ function generateContentAndTemplates() {
         markdownPage: fileName,
         pageStylesheet: fileName
       },
+      page: {
+        languages: projectJSON.languages.map(function(lang) {
+          return {
+            code: lang.code,
+            name: lang.name,
+            url: `/${lang.code}/${fileName}.html`
+          }
+        })
+      },
       project: projectJSON
     }
 

--- a/source/project.json
+++ b/source/project.json
@@ -2,7 +2,7 @@
   "current_version": "1.4.3",
   "current_v8": "4.1.0.21",
   "languages": [
-    {"code": "cn", "name": "中文", "name-en": "Chinese"},
+    {"code": "cn", "name": "简体中文", "name-en": "Chinese (Simple)"},
     {"code": "de", "name": "Deutsch", "name-en": "German"},
     {"code": "el", "name": "Ελληνικά", "name-en": "Greek"},
     {"code": "en", "name": "English", "name-en": "English"},
@@ -14,11 +14,12 @@
     {"code": "it", "name": "Italiano", "name-en": "Italian"},
     {"code": "ja", "name": "日本語", "name-en": "Japanese"},
     {"code": "ko", "name": "한국어", "name-en": "Korean"},
+    {"code": "no", "name": "Norsk", "name-en": "Norwegian"},
     {"code": "pt_BR", "name": "Português (BR)", "name-en": "Portuguese (Brazil)"},
     {"code": "pt_PT", "name": "Português (PT)", "name-en": "Portuguese (Portugal)"},
     {"code": "ru", "name": "Русский", "name-en": "Russian"},
     {"code": "tr", "name": "Türkçe", "name-en": "Turkish"},
     {"code": "uk", "name": "Українська", "name-en": "Ukrainian"},
-    {"code": "zh_TW", "name": "台灣", "name-en": "Chinese (Taiwan)"}
+    {"code": "zh_TW", "name": "正體中文（台灣）", "name-en": "Chinese Traditional (Taiwan)"}
   ]
 }

--- a/source/project.json
+++ b/source/project.json
@@ -1,4 +1,24 @@
 {
   "current_version": "1.4.3",
-  "current_v8": "4.1.0.21"
+  "current_v8": "4.1.0.21",
+  "languages": [
+    {"code": "cn", "name": "中文", "name-en": "Chinese"},
+    {"code": "de", "name": "Deutsch", "name-en": "German"},
+    {"code": "el", "name": "Ελληνικά", "name-en": "Greek"},
+    {"code": "en", "name": "English", "name-en": "English"},
+    {"code": "es", "name": "Español", "name-en": "Spanish"},
+    {"code": "fi", "name": "Suomi", "name-en": "Finnish"},
+    {"code": "fr", "name": "Français", "name-en": "French"},
+    {"code": "he", "name": "עברית", "name-en": "Hebrew", "rtl": true},
+    {"code": "id", "name": "Bahasa Indonesia", "name-en": "Indonesian"},
+    {"code": "it", "name": "Italiano", "name-en": "Italian"},
+    {"code": "ja", "name": "日本語", "name-en": "Japanese"},
+    {"code": "ko", "name": "한국어", "name-en": "Korean"},
+    {"code": "pt_BR", "name": "Português (BR)", "name-en": "Portuguese (Brazil)"},
+    {"code": "pt_PT", "name": "Português (PT)", "name-en": "Portuguese (Portugal)"},
+    {"code": "ru", "name": "Русский", "name-en": "Russian"},
+    {"code": "tr", "name": "Türkçe", "name-en": "Turkish"},
+    {"code": "uk", "name": "Українська", "name-en": "Ukrainian"},
+    {"code": "zh_TW", "name": "台灣", "name-en": "Chinese (Taiwan)"}
+  ]
 }

--- a/source/styles/main.styl
+++ b/source/styles/main.styl
@@ -131,10 +131,17 @@ nav
     &:first-child, &:hover, &:hover + a
       border-color transparent
 
+  a[href]
     &:hover
       background #F7DF31
       color #292829
       border-radius 3px
+
+  &.languageFooter
+    font-size 0.8rem
+    margin-top 30px
+    a
+      border-left-width 0px
 
 p.lead
   text-align center

--- a/source/templates/main.html
+++ b/source/templates/main.html
@@ -32,7 +32,9 @@
     </div>
   </header>
 
-  <div class="content clearfix">{{{content}}}</div>
+  <div class="content content--body clearfix">
+    {{{content}}}
+  </div>
 
   <footer class="content">
     <nav>
@@ -41,6 +43,10 @@
    --><a href="https://webchat.freenode.net/?channels=io.js">{{i18n.irc-link}}</a><!--
    --><a href="http://logs.libuv.org/io.js/latest">{{i18n.irc-logs-link}}</a><!--
    --><a href="https://github.com/iojs/io.js/blob/v1.x/GOVERNANCE.md#readme">{{i18n.gov-link}}</a>
+    </nav>
+    <nav class="languageFooter">
+      <a><strong>{{i18n.heading-languages}}</strong></h3><!--
+    -->{{#page.languages}}<a href="{{url}}" lang="{{code}}">{{name}}</a>{{/page.languages}}
     </nav>
   </footer>
 


### PR DESCRIPTION
Adds i18n footer links, merges against #257 **not master**

Notes:
- This list was originally a side bar, until I remembered this would look funny on the homepage, so it is a footer (for now.) I'd like to revisit having it in a sidebar again once we evolve the design more.
- The footer links are to the SAME article in the selected language. I'll cover the more advanced case of missing articles at a later time.
- I'll need to confirm with the i18n groups I got all of the names right (message sent)
- There's probably a better place to maintain this list of languages
- There is an "i18n" dictionary variable for the word "Languages" itself, which we fall back to English for when this isn't defined. See `中文` for this in action. (Shows `其他语言` instead of `Languages`.)

![iojs i18n footer screenshot](https://cloud.githubusercontent.com/assets/6534/6464608/b3a4a120-c1bb-11e4-84fa-ee7410d979d8.png)
