### PR TITLE
Indonesian URL format typo fix and some extra translations

### DIFF
--- a/content/id/index.md
+++ b/content/id/index.md
@@ -2,7 +2,7 @@
 
 Membawa [ES6](es6.html) ke Komunitas Node!
 
-[io.js](https://github.com/iojs/io.js) adalah [npm](https://www.npmjs.org/) platform yang kompatibel dengan [node.js](https: //nodejs.org/)™.
+[io.js](https://github.com/iojs/io.js) adalah [npm](https://www.npmjs.org/) platform yang kompatibel dengan [node.js](https://nodejs.org/)™.
 
 [![io.js](../images/1.0.0.png)](https://iojs.org/dist/v{{project.current_version}}/)
 

--- a/content/id/index.md
+++ b/content/id/index.md
@@ -12,8 +12,8 @@ Membawa [ES6](es6.html) ke Komunitas Node!
 Unduh untuk
 [Linux](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-linux-x64.tar.xz),
 [Win32](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-x86.msi), [Win64](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}-x64.msi),
-or
-[Mac](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}.pkg).
+[Mac](https://iojs.org/dist/v{{project.current_version}}/iojs-v{{project.current_version}}.pkg) atau
+[lainnya](https://iojs.org/dist/v{{project.current_version}}/).
 
 
 [Log Perubahan](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md)

--- a/content/id/index.md
+++ b/content/id/index.md
@@ -2,7 +2,7 @@
 
 Membawa [ES6](es6.html) ke Komunitas Node!
 
-[io.js](https://github.com/iojs/io.js) adalah [npm](https://www.npmjs.org/) platform yang kompatibel dengan [node.js] (https: //nodejs.org/)™.
+[io.js](https://github.com/iojs/io.js) adalah [npm](https://www.npmjs.org/) platform yang kompatibel dengan [node.js](https: //nodejs.org/)™.
 
 [![io.js](../images/1.0.0.png)](https://iojs.org/dist/v{{project.current_version}}/)
 

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -87,7 +87,7 @@ function generateContentAndTemplates() {
           return {
             code: lang.code,
             name: lang.name,
-            url: `/${lang.code}/${fileName}.html`
+            url: '/${lang.code}/${fileName}.html'
           }
         })
       },

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -87,7 +87,7 @@ function generateContentAndTemplates() {
           return {
             code: lang.code,
             name: lang.name,
-            url: '/${lang.code}/${fileName}.html'
+            url: `/${lang.code}/${fileName}.html`
           }
         })
       },


### PR DESCRIPTION
Mainly for fixing the Indonesian version of the link, but I included the gulp task typo for convenience (mentioned [here](https://github.com/iojs/website/pull/258#issuecomment-77202730)). I can rollback the commit if it's not the problem.