### PR TITLE
build process #264

### DIFF
--- a/content/en/template.json
+++ b/content/en/template.json
@@ -1,14 +1,21 @@
 {
-  "browser-title":"io.js - JavaScript I/O",
-  "contribute-message":"See something you like? Want to help? Visit https://github.com/iojs/website to contribute",
-  "heading-languages":"Languages",
-  "logo-text":"io.js",
-  "faq-link":"FAQ",
-  "es6-link":"ES6",
-  "api-link":"API Docs",
-  "issues-link":"GitHub Issues",
-  "org-link":"GitHub Org",
-  "irc-link":"IRC Chat",
-  "irc-logs-link":"Logs",
-  "gov-link":"Governance"
+  "browser-title": "io.js - JavaScript I/O",
+  "contribute-message": "See something you like? Want to help? Visit https://github.com/iojs/website to contribute",
+  "heading-languages": "Languages",
+  "logo-text": "io.js",
+  "faq-link": "FAQ",
+  "es6-link": "ES6",
+  "api-link": "API Docs",
+  "issues-link": "GitHub Issues",
+  "org-link": "GitHub Org",
+  "irc-link": "IRC Chat",
+  "irc-logs-link": "Logs",
+  "gov-link": "Governance",
+  "downloads": {
+    "linux": "Linux",
+    "win32": "Win32",
+    "win64": "Win64",
+    "mac": "Mac",
+    "all": "Others"
+  }
 }

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -55,7 +55,7 @@ function generateContentAndTemplates() {
    */
   base = path.resolve(__dirname, '..', '..'); /* 1 */
   contentBase = path.resolve(base, 'content'); /* 2 */
-  projectJSON = require('../../source/project.json'); /* 3 */
+  projectJSON = require('../../source/project.js'); /* 3 */
   i18nJSON = {}; /* 4 */
   hbsTemplates = {}; /* 5 */
 

--- a/gulp/util/template-utils.js
+++ b/gulp/util/template-utils.js
@@ -6,12 +6,19 @@ var CONTENT_DIRECTORY = 'content';
 // load template.json for given language, but use default language as fallback
 // for properties which are not present in the given language
 module.exports.loadTemplateJSON = function(lang) {
-  var defaultJSON = require('../../' + CONTENT_DIRECTORY + '/' + DEFAULT_LANG + '/template.json'); 
+  var defaultJSON = require('../../' + CONTENT_DIRECTORY + '/' + DEFAULT_LANG + '/template.json');
   var templateJSON = require('../../' + CONTENT_DIRECTORY + '/' + lang + '/template.json');
   var finalJSON = _.cloneDeep(defaultJSON);
-  _.forEach(templateJSON, function(value, key) {
-    finalJSON[key] = value;
-  });
+  var merge = function(targetJSON, customJSON) {
+    _.forEach(customJSON, function(value, key) {
+      if (typeof value === "object") {
+        merge(targetJSON[key], value)
+      } else {
+        targetJSON[key] = value;
+      }
+    });
+  }
+  merge(finalJSON, templateJSON)
   return finalJSON;
 };
 

--- a/source/project.js
+++ b/source/project.js
@@ -1,0 +1,46 @@
+// temporary merge to help avoid some merge confusion when landed:
+var project = require('./project.json');
+
+/*
+
+// This will replace `./project.json`
+
+project = {
+  "current_version": "1.4.3",
+  "current_v8": "4.1.0.21"
+}
+
+project.languages = [
+  {"code": "cn", "name": "简体中文", "name-en": "Chinese (Simple)"},
+  {"code": "de", "name": "Deutsch", "name-en": "German"},
+  {"code": "el", "name": "Ελληνικά", "name-en": "Greek"},
+  {"code": "en", "name": "English", "name-en": "English"},
+  {"code": "es", "name": "Español", "name-en": "Spanish"},
+  {"code": "fi", "name": "Suomi", "name-en": "Finnish"},
+  {"code": "fr", "name": "Français", "name-en": "French"},
+  {"code": "he", "name": "עברית", "name-en": "Hebrew", "rtl": true},
+  {"code": "id", "name": "Bahasa Indonesia", "name-en": "Indonesian"},
+  {"code": "it", "name": "Italiano", "name-en": "Italian"},
+  {"code": "ja", "name": "日本語", "name-en": "Japanese"},
+  {"code": "ko", "name": "한국어", "name-en": "Korean"},
+  {"code": "no", "name": "Norsk", "name-en": "Norwegian"},
+  {"code": "pt_BR", "name": "Português (BR)", "name-en": "Portuguese (Brazil)"},
+  {"code": "pt_PT", "name": "Português (PT)", "name-en": "Portuguese (Portugal)"},
+  {"code": "ru", "name": "Русский", "name-en": "Russian"},
+  {"code": "tr", "name": "Türkçe", "name-en": "Turkish"},
+  {"code": "uk", "name": "Українська", "name-en": "Ukrainian"},
+  {"code": "zh_TW", "name": "正體中文（台灣）", "name-en": "Chinese Traditional (Taiwan)"}
+]
+*/
+
+var baseURL = `https://iojs.org/dist`;
+project.current_version_downloads = [
+  {key: 'linux', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}-linux-x64.tar.xz`},
+  {key: 'win32', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}-x86.msi`},
+  {key: 'win64', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}-x64.msi`},
+  {key: 'mac', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}.pkg`},
+  {key: 'all', url: `${baseURL}/${project.current_version}/`}
+];
+Object.defineProperty(project.current_version_downloads, 'all', {value: `${baseURL}/${project.current_version}/`});
+
+module.exports = project;

--- a/source/project.js
+++ b/source/project.js
@@ -35,12 +35,12 @@ project.languages = [
 
 var baseURL = `https://iojs.org/dist`;
 project.current_version_downloads = [
-  {key: 'linux', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}-linux-x64.tar.xz`},
-  {key: 'win32', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}-x86.msi`},
-  {key: 'win64', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}-x64.msi`},
-  {key: 'mac', url: `${baseURL}/${project.current_version}/iojs-${project.current_version}.pkg`},
-  {key: 'all', url: `${baseURL}/${project.current_version}/`}
+  {key: 'linux', url: `${baseURL}/v${project.current_version}/iojs-v${project.current_version}-linux-x64.tar.xz`},
+  {key: 'win32', url: `${baseURL}/v${project.current_version}/iojs-v${project.current_version}-x86.msi`},
+  {key: 'win64', url: `${baseURL}/v${project.current_version}/iojs-v${project.current_version}-x64.msi`},
+  {key: 'mac', url: `${baseURL}/v${project.current_version}/iojs-v${project.current_version}.pkg`},
+  {key: 'all', url: `${baseURL}/v${project.current_version}/`}
 ];
-Object.defineProperty(project.current_version_downloads, 'all', {value: `${baseURL}/${project.current_version}/`});
+Object.defineProperty(project.current_version_downloads, 'all', {value: `${baseURL}/v${project.current_version}/`});
 
 module.exports = project;


### PR DESCRIPTION
Deep merge for i18n template.json, switches to `source/project.js` (vs json) --- one of many things for #264 

Not sure how little/big to break up these PRs to, but I have other work which builds off of this which is still isn't merge-ready. This part is fairly safe as is and gives some guidance to i18n teams on some upcoming dictionary additions (although there will probably be more as `index.md` -> `index.html`)