### PR TITLE
Gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install
 npm run gulp develop
 ```
 
-Or just run `gulp` if you have it installed globally. You can also run `npm run gulp build` to run the build script, if you don't wish to have a dev server running.
+Or just run `gulp develop` if you have it installed globally. You can also run `npm run gulp build` to run the build script, if you don't wish to have a dev server running.
 
 Runs a local HTTP server on port 4657 with live-reload, which will update
 your browser immediately with content or style changes. Generated assets

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 
 ### Local Development
 ```
-npm run gulp
+npm run gulp develop
 ```
 
 Or just run `gulp` if you have it installed globally. You can also run `npm run gulp build` to run the build script, if you don't wish to have a dev server running.

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -5,10 +5,10 @@ gulp.task('default', function(){
   var message =
   '---- io.js website ----\n' +
   'gulp tasks available:\n'   +
-  '- develop\n' +
-  '- build\n'   +
-  '- server\n'  +
-  '- clean\n';
+  '- develop // Runs the `build` and `server` tasks and also keeps a watcher running\n' +
+  '- build   // build the HTML and CSS files\n'   +
+  '- server  // start the local dev server\n'  +
+  '- clean   // clean out directory\n';
 
   console.log(message);
 });

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,10 +1,14 @@
 var gulp = require('gulp');
-var runSequence = require('run-sequence');
 
-gulp.task('default', function(cb){
-  runSequence(
-    // 'clean',
-    ['stylus', 'templates'],
-    ['watch', 'server'],
-  cb);
+gulp.task('default', function(){
+
+  var message =
+  '---- io.js website ----\n' +
+  'gulp tasks available:\n'   +
+  '- develop\n' +
+  '- build\n'   +
+  '- server\n'  +
+  '- clean\n';
+
+  console.log(message);
 });

--- a/gulp/tasks/develop.js
+++ b/gulp/tasks/develop.js
@@ -1,0 +1,10 @@
+var gulp = require('gulp');
+var runSequence = require('run-sequence');
+
+gulp.task('develop', function(cb){
+  runSequence(
+    // 'clean',
+    ['stylus', 'templates'],
+    ['watch', 'server'],
+  cb);
+});


### PR DESCRIPTION
Based on what we discussed on PR #265 I changed a bit the names of the gulp tasks, so it's clear which one is the `develop` one.
The default one just lists the options. 
( maybe we can add small comments there, but it's pretty obvious with the current options )