### PR TITLE
Lowercase `x-ua-compatible` meta info

### DIFF
--- a/source/templates/main.html
+++ b/source/templates/main.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>{{i18n.browser-title}}</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="x-ua-Compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="io.js is an npm compatible platform originally based on node.js">
   <meta name="keywords" content="iojs, io.js, io js, javascript io, uv, libuv, node-forward, node forward, node, node.js, node.js forward, nodejs, nodejs forward, javascript">


### PR DESCRIPTION
https://github.com/iojs/website/pull/298#issuecomment-85157675 Perfectly valid, so why not? It's consistent after all. 