### PR TITLE
Fixed transition on footer links

### DIFF
--- a/source/styles/main.styl
+++ b/source/styles/main.styl
@@ -126,7 +126,7 @@ nav
     padding 0 10px
     margin 0
     border-left 1px solid #DDD
-    transition background 0.2s, color 0.2s, border-radius 0.2s
+    transition background 0.2s, color 0.2s
 
     &:first-child, &:hover, &:hover + a
       border-color transparent

--- a/source/styles/main.styl
+++ b/source/styles/main.styl
@@ -126,7 +126,7 @@ nav
     padding 0 10px
     margin 0
     border-left 1px solid #DDD
-    transition all 0.2s
+    transition background 0.2s, color 0.2s, border-radius 0.2s
 
     &:first-child, &:hover, &:hover + a
       border-color transparent


### PR DESCRIPTION
I found this weird css transition on all changes to the footer nav links, making them kinda bulge on page load. I'm assuming that isn't desired. Made sure it only is transitioning on the attributes being changes on hover.
