### PR TITLE
Add external RSS feed discovery, see #79

### DIFF
--- a/content/en/template.json
+++ b/content/en/template.json
@@ -42,6 +42,12 @@
       "es6": "ES6",
       "faq": "FAQ",
       "faq_verbose": "Frequently Asked Questions"
-    }
+    },
+    "rss": [
+      {
+        "title": "Weekly Updates (Medium)",
+        "url": "https://medium.com/feed/@iojs"
+      }
+    ]
   }
 }

--- a/source/project.js
+++ b/source/project.js
@@ -20,7 +20,13 @@ project.links = {
     faq: './faq.html',
     faq_verbose: './faq.html',
     releases: './releases.html'
-  }
+  },
+  rss: [
+    {
+      title: 'Releases (GitHub)',
+      url: 'https://github.com/iojs/io.js/releases.atom'
+    }
+  ]
 };
 
 var baseURL = `https://iojs.org/dist`;

--- a/source/templates/main.html
+++ b/source/templates/main.html
@@ -24,6 +24,12 @@
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1369">
   <meta property="og:image:height" content="1563">
+  {{#each project.links.rss}}
+  <link rel="alternate" type="application/atom+xml" title="{{title}}" href="{{url}}" />
+  {{/each}}
+  {{#each i18n.links.rss}}
+  <link rel="alternate" type="application/atom+xml" title="{{title}}" href="{{url}}" />
+  {{/each}}
 </head>
 
 <body markdown-page="{{build.markdownPage}}">


### PR DESCRIPTION
Link to feeds for GitHub releases (global) and Medium posts, etc. (per language). Each language group can define a set of RSS feeds linking to their blogs, community pages, social network feeds, etc.