### PR TITLE
gulp: activate html minifier task

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -34,7 +34,7 @@ module.exports = {
     ]
   },
   cssSrc: dest + '/*.css',
-  htmlSrc: dest + '/*.html',
+  htmlSrc: dest + '/**/*.html',
   dest: dest,
   server: {
     port: 4657

--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -8,6 +8,7 @@ gulp.task('build', function(cb){
     'content',
     'copyStatic',
     ['stylus', 'templates'],
+    'minifyHtml',
     'minifyCss',
     cb);
 });

--- a/gulp/tasks/minifyHtml.js
+++ b/gulp/tasks/minifyHtml.js
@@ -3,9 +3,21 @@ var config     = require('../config');
 var minifyHTML = require('gulp-htmlmin');
 var size       = require('gulp-size');
 
+// See https://github.com/kangax/html-minifier#options-quick-reference
+var options = {
+  caseSensitive: true,
+  collapseBooleanAttributes: true,
+  collapseWhitespace: true,
+  ignoreCustomComments: [ /contribute/ ],
+  removeAttributeQuotes: true,
+  removeComments: true,
+  removeOptionalTags: true,
+  removeRedundantAttributes: true
+};
+
 gulp.task('minifyHtml', function() {
   return gulp.src(config.htmlSrc)
-    .pipe(minifyHTML())
+    .pipe(minifyHTML(options))
     .pipe(gulp.dest(config.dest))
     .pipe(size({title: 'minifyHtml'}));
 });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-clone": "^1.0.0",
     "gulp-compile-handlebars": "^0.4.4",
     "gulp-connect": "^2.2.0",
-    "gulp-htmlmin": "^1.0.0",
+    "gulp-htmlmin": "^1.1.1",
     "gulp-imagemin": "^2.1.0",
     "gulp-markdown": "^1.0.0",
     "gulp-postcss": "^4.0.2",


### PR DESCRIPTION
Noticed HTML wasn't minified yet, decided to fix it. This keeps the special contributor comment we have intact.

The gulp tasks are getting a bit spammy on the command line, maybe it's time to deactivate the file size logging for each file.

cc: @therebelrobot  