### PR TITLE
s/doc\//docs\// to match change in release process

### DIFF
--- a/source/templates/releases.html
+++ b/source/templates/releases.html
@@ -20,7 +20,7 @@
         <a href="https://github.com/nodejs/io.js/blob/{{version}}/CHANGELOG.md">
           {{i18n 'links.pages.changelog'}}
         </a>
-        <a href="https://iojs.org/dist/{{version}}/doc/api/">
+        <a href="https://iojs.org/dist/{{version}}/docs/api/">
           {{i18n 'api-link'}}
         </a>
       </div>


### PR DESCRIPTION
this change was done at the build end to match how nodejs.org expects
the directories to be named. All releases _prior_ to v3.3.0 have a
symlink from doc to docs so using docs exclusively now should work
